### PR TITLE
Decimal test widget

### DIFF
--- a/Applications/Spire/Include/Spire/Spire/SpinBoxModel.hpp
+++ b/Applications/Spire/Include/Spire/Spire/SpinBoxModel.hpp
@@ -88,7 +88,7 @@ namespace Spire {
   }
 
   template<typename T>
-  void set_initial(T initial) {
+  void SpinBoxModel<T>::set_initial(T initial) {
     m_initial = initial;
   }
 

--- a/Applications/Spire/Include/Spire/UiViewer/DecimalSpinBoxTestWidget.hpp
+++ b/Applications/Spire/Include/Spire/UiViewer/DecimalSpinBoxTestWidget.hpp
@@ -1,0 +1,40 @@
+#ifndef SPIRE_DECIMAL_SPIN_BOX_TEST_WIDGET_HPP
+#define SPIRE_DECIMAL_SPIN_BOX_TEST_WIDGET_HPP
+#include <QGridLayout>
+#include <QLabel>
+#include "Spire/Ui/DecimalSpinBox.hpp"
+#include "Spire/Ui/StaticDropDownMenu.hpp"
+#include "Spire/Ui/TextInputWidget.hpp"
+
+namespace Spire {
+
+  //! Represents a widget for testing a DecimalSpinBox.
+  class DecimalSpinBoxTestWidget : public QWidget {
+    public:
+
+      //! Constructs a DecimalSpinBoxTestWidget.
+      /*!
+        \param parent The parent widget.
+      */
+      DecimalSpinBoxTestWidget(QWidget* parent = nullptr);
+
+    private:
+      QGridLayout* m_layout;
+      std::shared_ptr<DecimalSpinBoxModel> m_model;
+      DecimalSpinBox* m_spin_box;
+      QLabel* m_value_label;
+      TextInputWidget* m_initial_input;
+      TextInputWidget* m_min_input;
+      TextInputWidget* m_max_input;
+      TextInputWidget* m_increment_input;
+      StaticDropDownMenu* m_modifier_menu;
+
+      void reset_spin_box();
+      void on_initial_set();
+      void on_min_set();
+      void on_max_set();
+      void on_increment_set();
+  };
+}
+
+#endif

--- a/Applications/Spire/Include/Spire/UiViewer/DecimalSpinBoxTestWidget.hpp
+++ b/Applications/Spire/Include/Spire/UiViewer/DecimalSpinBoxTestWidget.hpp
@@ -1,44 +1,44 @@
 #ifndef SPIRE_DECIMAL_SPIN_BOX_TEST_WIDGET_HPP
 #define SPIRE_DECIMAL_SPIN_BOX_TEST_WIDGET_HPP
-#include <QGridLayout>
-#include <QLabel>
+#include <QHBoxLayout>
 #include "Spire/Ui/DecimalSpinBox.hpp"
-#include "Spire/Ui/StaticDropDownMenu.hpp"
-#include "Spire/Ui/TextInputWidget.hpp"
+#include "Spire/UiViewer/SpinBoxAdapter.hpp"
 
 namespace Spire {
 
-  //! Represents a widget for testing a DecimalSpinBox.
-  class DecimalSpinBoxTestWidget : public QWidget {
+  class DecimalSpinBoxTestWidget : public SpinBoxAdapter {
     public:
 
-      //! Constructs a DecimalSpinBoxTestWidget.
-      /*!
-        \param parent The parent widget.
-      */
       DecimalSpinBoxTestWidget(QWidget* parent = nullptr);
 
-    private:
-      QGridLayout* m_layout;
-      std::shared_ptr<DecimalSpinBoxModel> m_model;
-      DecimalSpinBox* m_spin_box;
-      QLabel* m_value_label;
-      TextInputWidget* m_initial_input;
-      TextInputWidget* m_min_input;
-      TextInputWidget* m_max_input;
-      TextInputWidget* m_increment_input;
-      StaticDropDownMenu* m_modifier_menu;
-      QLabel* m_no_increment_label;
-      QLabel* m_shift_increment_label;
-      QLabel* m_ctrl_increment_label;
-      QLabel* m_ctrl_shift_increment_label;
+      bool reset(const QString& initial, const QString& minimum,
+        const QString& maximum, const QString& increment) override;
 
-      void reset_spin_box();
-      void update_increment_labels();
-      void on_initial_set();
-      void on_min_set();
-      void on_max_set();
-      void on_increment_set();
+      QString get_initial() const override;
+
+      bool set_initial(const QString& initial) override;
+
+      QString get_minimum() const override;
+
+      bool set_minimum(const QString& minimum) override;
+
+      QString get_maximum() const override;
+
+      bool set_maximum(const QString& maximum) override;
+
+      QString get_increment(Qt::KeyboardModifiers modifiers) const override;
+
+      bool set_increment(Qt::KeyboardModifiers modifiers,
+        const QString& increment) override;
+
+      boost::signals2::connection connect_change_signal(
+        const ChangeSignal::slot_type& slot) const override;
+
+    private:
+      mutable ChangeSignal m_change_signal;
+      DecimalSpinBox* m_spin_box;
+      std::shared_ptr<DecimalSpinBoxModel> m_model;
+      QHBoxLayout* m_layout;
   };
 }
 

--- a/Applications/Spire/Include/Spire/UiViewer/DecimalSpinBoxTestWidget.hpp
+++ b/Applications/Spire/Include/Spire/UiViewer/DecimalSpinBoxTestWidget.hpp
@@ -6,9 +6,14 @@
 
 namespace Spire {
 
+  //! Represents a widget for interacting with a DecimalSpinBox being tested.
   class DecimalSpinBoxTestWidget : public SpinBoxAdapter {
     public:
 
+      //! Constructs a DecimalSpinBoxTestWidget.
+      /*
+        \param parent The parent widget.
+      */
       DecimalSpinBoxTestWidget(QWidget* parent = nullptr);
 
       bool reset(const QString& initial, const QString& minimum,

--- a/Applications/Spire/Include/Spire/UiViewer/DecimalSpinBoxTestWidget.hpp
+++ b/Applications/Spire/Include/Spire/UiViewer/DecimalSpinBoxTestWidget.hpp
@@ -28,8 +28,13 @@ namespace Spire {
       TextInputWidget* m_max_input;
       TextInputWidget* m_increment_input;
       StaticDropDownMenu* m_modifier_menu;
+      QLabel* m_no_increment_label;
+      QLabel* m_shift_increment_label;
+      QLabel* m_ctrl_increment_label;
+      QLabel* m_ctrl_shift_increment_label;
 
       void reset_spin_box();
+      void update_increment_labels();
       void on_initial_set();
       void on_min_set();
       void on_max_set();

--- a/Applications/Spire/Include/Spire/UiViewer/SpinBoxAdapter.hpp
+++ b/Applications/Spire/Include/Spire/UiViewer/SpinBoxAdapter.hpp
@@ -5,35 +5,83 @@
 
 namespace Spire {
 
+  //! Provides an adapter for testing a spin box and the associated model.
   class SpinBoxAdapter : public QWidget {
     public:
 
+      //! Signal type for spin box value changes.
+      /*
+        \param value The updated value.
+      */
       using ChangeSignal = Signal<void (const QString& value)>;
 
+      //! Constructs a SpinBoxAdapter.
+      /*
+        \param parent The parent widget.
+      */
       SpinBoxAdapter(QWidget* parent = nullptr);
 
       virtual ~SpinBoxAdapter() = default;
 
+      //! Replaces the current spin box and associated model, iff the provided
+      //! values are valid numbers.
+      /*!
+        \param initial The model's initial value.
+        \param minimum The model's minimum value.
+        \param minimum The model's maximum value.
+        \param increment The model's default increment.
+        \return True iff the spin box and model were reset successfully.
+      */
       virtual bool reset(const QString& initial, const QString& minimum,
         const QString& maximum, const QString& increment) = 0;
 
+      //! Returns the model's initial value.
       virtual QString get_initial() const = 0;
 
+      //! Sets the model's initial value iff the given value is a valid number.
+      /*!
+        \param initial The initial value.
+        \return True iff the initial value was set successfully.
+      */
       virtual bool set_initial(const QString& initial) = 0;
 
+      //! Returns the model's minimum value.
       virtual QString get_minimum() const = 0;
 
+      //! Sets the model's minimum value iff the given value is a valid number.
+      /*!
+        \param minimum The minimum value.
+        \return True iff the minimum was set successfully.
+      */
       virtual bool set_minimum(const QString& minimum) = 0;
 
+      //! Returns the model's maximum value.
       virtual QString get_maximum() const = 0;
 
+      //! Sets the model's maximum value iff the given value is a valid number.
+      /*!
+        \param maximum The maximum value.
+        \return True iff the maximum was set successfully.
+      */
       virtual bool set_maximum(const QString& maximum) = 0;
 
+      //! Returns the increment for the given key modifiers.
+      /*!
+        \param modifiers The key modifiers.
+      */
       virtual QString get_increment(Qt::KeyboardModifiers modifiers) const = 0;
 
+      //! Sets the increment for the given key modifiers, iff the given
+      //! increment is a valid number.
+      /*!
+        \param modifiers The key modifiers.
+        \param increment The increment for the given key modifiers.
+        \return True iff the increment was set successfully.
+      */
       virtual bool set_increment(Qt::KeyboardModifiers modifiers,
         const QString& increment) = 0;
 
+      //! Connects a slot to the value change signal.
       virtual boost::signals2::connection connect_change_signal(
         const ChangeSignal::slot_type& slot) const = 0;
   };

--- a/Applications/Spire/Include/Spire/UiViewer/SpinBoxAdapter.hpp
+++ b/Applications/Spire/Include/Spire/UiViewer/SpinBoxAdapter.hpp
@@ -1,0 +1,42 @@
+#ifndef SPIRE_SPIN_BOX_TEST_WIDGET_ADAPTER_HPP
+#define SPIRE_SPIN_BOX_TEST_WIDGET_ADAPTER_HPP
+#include <QWidget>
+#include "Spire/Spire/Spire.hpp"
+
+namespace Spire {
+
+  class SpinBoxAdapter : public QWidget {
+    public:
+
+      using ChangeSignal = Signal<void (const QString& value)>;
+
+      SpinBoxAdapter(QWidget* parent = nullptr);
+
+      virtual ~SpinBoxAdapter() = default;
+
+      virtual bool reset(const QString& initial, const QString& minimum,
+        const QString& maximum, const QString& increment) = 0;
+
+      virtual QString get_initial() const = 0;
+
+      virtual bool set_initial(const QString& initial) = 0;
+
+      virtual QString get_minimum() const = 0;
+
+      virtual bool set_minimum(const QString& minimum) = 0;
+
+      virtual QString get_maximum() const = 0;
+
+      virtual bool set_maximum(const QString& maximum) = 0;
+
+      virtual QString get_increment(Qt::KeyboardModifiers modifiers) const = 0;
+
+      virtual bool set_increment(Qt::KeyboardModifiers modifiers,
+        const QString& increment) = 0;
+
+      virtual boost::signals2::connection connect_change_signal(
+        const ChangeSignal::slot_type& slot) const = 0;
+  };
+}
+
+#endif

--- a/Applications/Spire/Include/Spire/UiViewer/SpinBoxTestWidget.hpp
+++ b/Applications/Spire/Include/Spire/UiViewer/SpinBoxTestWidget.hpp
@@ -1,0 +1,45 @@
+#ifndef SPIRE_SPIN_BOX_TEST_WIDGET_HPP
+#define SPIRE_SPIN_BOX_TEST_WIDGET_HPP
+#include <QGridLayout>
+#include <QLabel>
+#include "Spire/Ui/StaticDropDownMenu.hpp"
+#include "Spire/Ui/TextInputWidget.hpp"
+#include "Spire/UiViewer/SpinBoxAdapter.hpp"
+
+namespace Spire {
+
+  //! Represents a widget for testing Spire spin boxes.
+  class SpinBoxTestWidget : public QWidget {
+    public:
+
+      //! Constructs a SpinBoxTestWidget.
+      /*!
+        \param parent The parent widget.
+      */
+      SpinBoxTestWidget(SpinBoxAdapter* spin_box, QWidget* parent = nullptr);
+
+    private:
+      boost::signals2::scoped_connection m_change_connection;
+      QGridLayout* m_layout;
+      SpinBoxAdapter* m_spin_box;
+      QLabel* m_value_label;
+      TextInputWidget* m_initial_input;
+      TextInputWidget* m_min_input;
+      TextInputWidget* m_max_input;
+      TextInputWidget* m_increment_input;
+      StaticDropDownMenu* m_modifier_menu;
+      QLabel* m_no_increment_label;
+      QLabel* m_shift_increment_label;
+      QLabel* m_ctrl_increment_label;
+      QLabel* m_ctrl_shift_increment_label;
+
+      void reset_spin_box();
+      void update_increment_labels();
+      void on_initial_set();
+      void on_min_set();
+      void on_max_set();
+      void on_increment_set();
+  };
+}
+
+#endif

--- a/Applications/Spire/Include/Spire/UiViewer/UiViewer.hpp
+++ b/Applications/Spire/Include/Spire/UiViewer/UiViewer.hpp
@@ -3,7 +3,10 @@
 
 namespace Spire {
   class ColorSelectorButtonTestWidget;
+  class DecimalSpinBoxTestWidget;
   class FlatButtonTestWidget;
+  class SpinBoxAdapter;
+  class SpinBoxTestWidget;
   class UiViewerWindow;
 }
 

--- a/Applications/Spire/Source/UiViewer/DecimalSpinBoxTestWidget.cpp
+++ b/Applications/Spire/Source/UiViewer/DecimalSpinBoxTestWidget.cpp
@@ -81,6 +81,22 @@ DecimalSpinBoxTestWidget::DecimalSpinBoxTestWidget(QWidget* parent)
   reset_button->setFixedHeight(scale_height(26));
   reset_button->connect_clicked_signal([=] { reset_spin_box(); });
   m_layout->addWidget(reset_button, 5, 0, 1, 2);
+  auto no_label = new QLabel(NO_MODIFIER, this);
+  m_layout->addWidget(no_label, 6, 0);
+  m_no_increment_label = new QLabel(this);
+  m_layout->addWidget(m_no_increment_label, 6, 1);
+  auto shift_label = new QLabel(SHIFT_MODIFIER, this);
+  m_layout->addWidget(shift_label, 7, 0);
+  m_shift_increment_label = new QLabel(this);
+  m_layout->addWidget(m_shift_increment_label, 7, 1);
+  auto ctrl_label = new QLabel(CTRL_MODIFIER, this);
+  m_layout->addWidget(ctrl_label, 8, 0);
+  m_ctrl_increment_label = new QLabel(this);
+  m_layout->addWidget(m_ctrl_increment_label, 8, 1);
+  auto shift_ctrl_label = new QLabel(CTRL_SHIFT_MODIFIER, this);
+  m_layout->addWidget(shift_ctrl_label, 9, 0);
+  m_ctrl_shift_increment_label = new QLabel(this);
+  m_layout->addWidget(m_ctrl_shift_increment_label, 9, 1);
   reset_spin_box();
 }
 
@@ -89,7 +105,8 @@ void DecimalSpinBoxTestWidget::reset_spin_box() {
   auto min = get_value(m_min_input->text());
   auto max = get_value(m_max_input->text());
   auto increment = get_value(m_increment_input->text());
-  if(initial && min && max && increment) {
+  if(initial && min && max && increment && min < max && min <= initial &&
+      initial <= max) {
     m_model = std::make_shared<DecimalSpinBoxModel>(*initial, *min, *max,
       *increment);
     delete_later(m_spin_box);
@@ -99,9 +116,22 @@ void DecimalSpinBoxTestWidget::reset_spin_box() {
       m_value_label->setText(QString::number(value));
     });
     m_layout->addWidget(m_spin_box, 0, 0);
+    update_increment_labels();
+    m_spin_box->setFocus();
   } else {
     m_value_label->setText(tr("Failed"));
   }
+}
+
+void DecimalSpinBoxTestWidget::update_increment_labels() {
+  m_no_increment_label->setText(QString::number(m_model->get_increment(
+    Qt::NoModifier)));
+  m_shift_increment_label->setText(QString::number(m_model->get_increment(
+    Qt::ShiftModifier)));
+  m_ctrl_increment_label->setText(QString::number(m_model->get_increment(
+    Qt::ControlModifier)));
+  m_ctrl_shift_increment_label->setText(QString::number(m_model->get_increment(
+    Qt::ControlModifier | Qt::ShiftModifier)));
 }
 
 void DecimalSpinBoxTestWidget::on_initial_set() {
@@ -120,7 +150,7 @@ void DecimalSpinBoxTestWidget::on_min_set() {
 
 void DecimalSpinBoxTestWidget::on_max_set() {
   if(auto max = get_value(m_max_input->text()); max) {
-    m_model->set_minimum(*max);
+    m_model->set_maximum(*max);
     m_value_label->setText("Max set");
   }
 }
@@ -130,5 +160,6 @@ void DecimalSpinBoxTestWidget::on_increment_set() {
     m_model->set_increment(get_modifier(
       m_modifier_menu->get_current_item().value<QString>()), *modifier);
     m_value_label->setText("Increment set");
+    update_increment_labels();
   }
 }

--- a/Applications/Spire/Source/UiViewer/DecimalSpinBoxTestWidget.cpp
+++ b/Applications/Spire/Source/UiViewer/DecimalSpinBoxTestWidget.cpp
@@ -1,0 +1,134 @@
+#include "Spire/UiViewer/DecimalSpinBoxTestWidget.hpp"
+#include "Spire/Spire/Dimensions.hpp"
+#include "Spire/Spire/Utility.hpp"
+#include "Spire/Ui/FlatButton.hpp"
+
+using namespace boost;
+using namespace Spire;
+
+namespace {
+  const auto NO_MODIFIER = QString(QObject::tr("NoModifier"));
+  const auto SHIFT_MODIFIER = QString(QObject::tr("Shift"));
+  const auto CTRL_MODIFIER = QString(QObject::tr("Control"));
+  const auto CTRL_SHIFT_MODIFIER = QString(QObject::tr("Shift + Control"));
+
+  auto CONTROL_SIZE() {
+    static auto size = scale(100, 26);
+    return size;
+  }
+
+  Qt::KeyboardModifiers get_modifier(const QString& text) {
+    if(text == NO_MODIFIER) {
+      return Qt::NoModifier;
+    } else if(text == SHIFT_MODIFIER) {
+      return Qt::ShiftModifier;
+    } else if(text == CTRL_MODIFIER) {
+      return Qt::ControlModifier;
+    } else if(text == CTRL_SHIFT_MODIFIER) {
+      return Qt::ControlModifier | Qt::ShiftModifier;
+    }
+    return Qt::NoModifier;
+  }
+  
+  optional<double> get_value(const QString& text) {
+    auto ok = false;
+    auto value = text.toDouble(&ok);
+    if(ok) {
+      return value;
+    }
+    return none;
+  }
+}
+
+DecimalSpinBoxTestWidget::DecimalSpinBoxTestWidget(QWidget* parent)
+    : QWidget(parent),
+      m_spin_box(nullptr) {
+  auto container_widget = new QWidget(this);
+  m_layout = new QGridLayout(container_widget);
+  m_value_label = new QLabel(this);
+  m_layout->addWidget(m_value_label, 0, 1);
+  auto initial_label = new QLabel(tr("Initial"), this);
+  m_layout->addWidget(initial_label, 1, 0);
+  m_initial_input = new TextInputWidget("0", this);
+  m_initial_input->setFixedSize(CONTROL_SIZE());
+  connect(m_initial_input, &TextInputWidget::editingFinished, this,
+    &DecimalSpinBoxTestWidget::on_initial_set);
+  m_layout->addWidget(m_initial_input, 1, 1);
+  auto min_label = new QLabel(tr("Minimum"), this);
+  m_layout->addWidget(min_label, 2, 0);
+  m_min_input = new TextInputWidget("-1000", this);
+  m_min_input->setFixedSize(CONTROL_SIZE());
+  connect(m_min_input, &TextInputWidget::editingFinished, this,
+    &DecimalSpinBoxTestWidget::on_min_set);
+  m_layout->addWidget(m_min_input, 2, 1);
+  auto max_label = new QLabel(tr("Maximum"), this);
+  m_layout->addWidget(max_label, 3, 0);
+  m_max_input = new TextInputWidget("1000", this);
+  m_max_input->setFixedSize(CONTROL_SIZE());
+  connect(m_max_input, &TextInputWidget::editingFinished, this,
+    &DecimalSpinBoxTestWidget::on_max_set);
+  m_layout->addWidget(m_max_input, 3, 1);
+  m_modifier_menu = new StaticDropDownMenu({NO_MODIFIER, SHIFT_MODIFIER,
+    CTRL_MODIFIER, CTRL_SHIFT_MODIFIER}, this);
+  m_modifier_menu->setFixedSize(CONTROL_SIZE());
+  m_layout->addWidget(m_modifier_menu, 4, 0);
+  m_increment_input = new TextInputWidget("1", this);
+  m_increment_input->setFixedSize(CONTROL_SIZE());
+  connect(m_increment_input, &TextInputWidget::editingFinished, this,
+    &DecimalSpinBoxTestWidget::on_increment_set);
+  m_layout->addWidget(m_increment_input, 4, 1);
+  auto reset_button = make_flat_button(tr("Reset"), this);
+  reset_button->setFixedHeight(scale_height(26));
+  reset_button->connect_clicked_signal([=] { reset_spin_box(); });
+  m_layout->addWidget(reset_button, 5, 0, 1, 2);
+  reset_spin_box();
+}
+
+void DecimalSpinBoxTestWidget::reset_spin_box() {
+  auto initial = get_value(m_initial_input->text());
+  auto min = get_value(m_min_input->text());
+  auto max = get_value(m_max_input->text());
+  auto increment = get_value(m_increment_input->text());
+  if(initial && min && max && increment) {
+    m_model = std::make_shared<DecimalSpinBoxModel>(*initial, *min, *max,
+      *increment);
+    delete_later(m_spin_box);
+    m_spin_box = new DecimalSpinBox(m_model, this);
+    m_spin_box->setFixedSize(CONTROL_SIZE());
+    m_spin_box->connect_change_signal([=] (auto value) {
+      m_value_label->setText(QString::number(value));
+    });
+    m_layout->addWidget(m_spin_box, 0, 0);
+  } else {
+    m_value_label->setText(tr("Failed"));
+  }
+}
+
+void DecimalSpinBoxTestWidget::on_initial_set() {
+  if(auto initial = get_value(m_initial_input->text()); initial) {
+    m_model->set_initial(*initial);
+    m_value_label->setText("Initial set");
+  }
+}
+
+void DecimalSpinBoxTestWidget::on_min_set() {
+  if(auto min = get_value(m_min_input->text()); min) {
+    m_model->set_minimum(*min);
+    m_value_label->setText("Min set");
+  }
+}
+
+void DecimalSpinBoxTestWidget::on_max_set() {
+  if(auto max = get_value(m_max_input->text()); max) {
+    m_model->set_minimum(*max);
+    m_value_label->setText("Max set");
+  }
+}
+
+void DecimalSpinBoxTestWidget::on_increment_set() {
+  if(auto modifier = get_value(m_increment_input->text()); modifier) {
+    m_model->set_increment(get_modifier(
+      m_modifier_menu->get_current_item().value<QString>()), *modifier);
+    m_value_label->setText("Increment set");
+  }
+}

--- a/Applications/Spire/Source/UiViewer/DecimalSpinBoxTestWidget.cpp
+++ b/Applications/Spire/Source/UiViewer/DecimalSpinBoxTestWidget.cpp
@@ -1,35 +1,12 @@
 #include "Spire/UiViewer/DecimalSpinBoxTestWidget.hpp"
 #include "Spire/Spire/Dimensions.hpp"
 #include "Spire/Spire/Utility.hpp"
-#include "Spire/Ui/FlatButton.hpp"
 
 using namespace boost;
+using namespace boost::signals2;
 using namespace Spire;
 
 namespace {
-  const auto NO_MODIFIER = QString(QObject::tr("NoModifier"));
-  const auto SHIFT_MODIFIER = QString(QObject::tr("Shift"));
-  const auto CTRL_MODIFIER = QString(QObject::tr("Control"));
-  const auto CTRL_SHIFT_MODIFIER = QString(QObject::tr("Shift + Control"));
-
-  auto CONTROL_SIZE() {
-    static auto size = scale(100, 26);
-    return size;
-  }
-
-  Qt::KeyboardModifiers get_modifier(const QString& text) {
-    if(text == NO_MODIFIER) {
-      return Qt::NoModifier;
-    } else if(text == SHIFT_MODIFIER) {
-      return Qt::ShiftModifier;
-    } else if(text == CTRL_MODIFIER) {
-      return Qt::ControlModifier;
-    } else if(text == CTRL_SHIFT_MODIFIER) {
-      return Qt::ControlModifier | Qt::ShiftModifier;
-    }
-    return Qt::NoModifier;
-  }
-  
   optional<double> get_value(const QString& text) {
     auto ok = false;
     auto value = text.toDouble(&ok);
@@ -41,125 +18,91 @@ namespace {
 }
 
 DecimalSpinBoxTestWidget::DecimalSpinBoxTestWidget(QWidget* parent)
-    : QWidget(parent),
+    : SpinBoxAdapter(parent),
       m_spin_box(nullptr) {
-  auto container_widget = new QWidget(this);
-  m_layout = new QGridLayout(container_widget);
-  m_value_label = new QLabel(this);
-  m_layout->addWidget(m_value_label, 0, 1, Qt::AlignCenter);
-  auto initial_label = new QLabel(tr("Initial"), this);
-  m_layout->addWidget(initial_label, 1, 0);
-  m_initial_input = new TextInputWidget("0", this);
-  m_initial_input->setFixedSize(CONTROL_SIZE());
-  connect(m_initial_input, &TextInputWidget::editingFinished, this,
-    &DecimalSpinBoxTestWidget::on_initial_set);
-  m_layout->addWidget(m_initial_input, 1, 1);
-  auto min_label = new QLabel(tr("Minimum"), this);
-  m_layout->addWidget(min_label, 2, 0);
-  m_min_input = new TextInputWidget("-1000", this);
-  m_min_input->setFixedSize(CONTROL_SIZE());
-  connect(m_min_input, &TextInputWidget::editingFinished, this,
-    &DecimalSpinBoxTestWidget::on_min_set);
-  m_layout->addWidget(m_min_input, 2, 1);
-  auto max_label = new QLabel(tr("Maximum"), this);
-  m_layout->addWidget(max_label, 3, 0);
-  m_max_input = new TextInputWidget("1000", this);
-  m_max_input->setFixedSize(CONTROL_SIZE());
-  connect(m_max_input, &TextInputWidget::editingFinished, this,
-    &DecimalSpinBoxTestWidget::on_max_set);
-  m_layout->addWidget(m_max_input, 3, 1);
-  m_modifier_menu = new StaticDropDownMenu({NO_MODIFIER, SHIFT_MODIFIER,
-    CTRL_MODIFIER, CTRL_SHIFT_MODIFIER}, this);
-  m_modifier_menu->setFixedSize(CONTROL_SIZE());
-  m_layout->addWidget(m_modifier_menu, 4, 0);
-  m_increment_input = new TextInputWidget("1", this);
-  m_increment_input->setFixedSize(CONTROL_SIZE());
-  connect(m_increment_input, &TextInputWidget::editingFinished, this,
-    &DecimalSpinBoxTestWidget::on_increment_set);
-  m_layout->addWidget(m_increment_input, 4, 1);
-  auto reset_button = make_flat_button(tr("Reset"), this);
-  reset_button->setFixedHeight(scale_height(26));
-  reset_button->connect_clicked_signal([=] { reset_spin_box(); });
-  m_layout->addWidget(reset_button, 5, 0, 1, 2);
-  auto no_label = new QLabel(NO_MODIFIER, this);
-  m_layout->addWidget(no_label, 6, 0);
-  m_no_increment_label = new QLabel(this);
-  m_layout->addWidget(m_no_increment_label, 6, 1);
-  auto shift_label = new QLabel(SHIFT_MODIFIER, this);
-  m_layout->addWidget(shift_label, 7, 0);
-  m_shift_increment_label = new QLabel(this);
-  m_layout->addWidget(m_shift_increment_label, 7, 1);
-  auto ctrl_label = new QLabel(CTRL_MODIFIER, this);
-  m_layout->addWidget(ctrl_label, 8, 0);
-  m_ctrl_increment_label = new QLabel(this);
-  m_layout->addWidget(m_ctrl_increment_label, 8, 1);
-  auto shift_ctrl_label = new QLabel(CTRL_SHIFT_MODIFIER, this);
-  m_layout->addWidget(shift_ctrl_label, 9, 0);
-  m_ctrl_shift_increment_label = new QLabel(this);
-  m_layout->addWidget(m_ctrl_shift_increment_label, 9, 1);
-  reset_spin_box();
+  m_layout = new QHBoxLayout(this);
+  m_layout->setContentsMargins({});
 }
 
-void DecimalSpinBoxTestWidget::reset_spin_box() {
-  auto initial = get_value(m_initial_input->text());
-  auto min = get_value(m_min_input->text());
-  auto max = get_value(m_max_input->text());
-  auto increment = get_value(m_increment_input->text());
-  if(initial && min && max && increment && min < max && min <= initial &&
-      initial <= max) {
-    m_model = std::make_shared<DecimalSpinBoxModel>(*initial, *min, *max,
-      *increment);
+bool DecimalSpinBoxTestWidget::reset(const QString& initial,
+    const QString& minimum, const QString& maximum, const QString& increment) {
+  auto initial_value = get_value(initial);
+  auto min_value = get_value(minimum);
+  auto max_value = get_value(maximum);
+  auto increment_value = get_value(increment);
+  if(initial_value && min_value && max_value && increment_value &&
+      *min_value < *max_value && *min_value <= *initial_value &&
+      *initial_value <= *max_value) {
+    m_model = std::make_shared<DecimalSpinBoxModel>(*initial_value, *min_value,
+      *max_value, *increment_value);
     delete_later(m_spin_box);
     m_spin_box = new DecimalSpinBox(m_model, this);
-    m_spin_box->setFixedSize(CONTROL_SIZE());
+    setFocusProxy(m_spin_box);
+    m_spin_box->setFixedSize(scale(100, 26));
     m_spin_box->connect_change_signal([=] (auto value) {
-      m_value_label->setText(QString::number(value));
+      m_change_signal(QString::number(value, 'g', 10));
     });
-    m_layout->addWidget(m_spin_box, 0, 0);
-    update_increment_labels();
-    m_spin_box->setFocus();
-  } else {
-    m_value_label->setText(tr("Failed"));
+    m_layout->addWidget(m_spin_box);
+    return true;
   }
+  return false;
 }
 
-void DecimalSpinBoxTestWidget::update_increment_labels() {
-  m_no_increment_label->setText(QString::number(m_model->get_increment(
-    Qt::NoModifier)));
-  m_shift_increment_label->setText(QString::number(m_model->get_increment(
-    Qt::ShiftModifier)));
-  m_ctrl_increment_label->setText(QString::number(m_model->get_increment(
-    Qt::ControlModifier)));
-  m_ctrl_shift_increment_label->setText(QString::number(m_model->get_increment(
-    Qt::ControlModifier | Qt::ShiftModifier)));
+QString DecimalSpinBoxTestWidget::get_initial() const {
+  return QString::number(m_model->get_initial());
 }
 
-void DecimalSpinBoxTestWidget::on_initial_set() {
-  if(auto initial = get_value(m_initial_input->text()); initial) {
-    m_model->set_initial(*initial);
-    m_value_label->setText("Initial set");
+bool DecimalSpinBoxTestWidget::set_initial(const QString& initial) {
+  if(auto initial_value = get_value(initial);
+      m_model->get_minimum() <= *initial_value &&
+      *initial_value <= m_model->get_maximum()) {
+    m_model->set_initial(*initial_value);
+    return true;
   }
+  return false;
 }
 
-void DecimalSpinBoxTestWidget::on_min_set() {
-  if(auto min = get_value(m_min_input->text()); min) {
-    m_model->set_minimum(*min);
-    m_value_label->setText("Min set");
-  }
+QString DecimalSpinBoxTestWidget::get_minimum() const {
+  return QString::number(m_model->get_minimum());
 }
 
-void DecimalSpinBoxTestWidget::on_max_set() {
-  if(auto max = get_value(m_max_input->text()); max) {
-    m_model->set_maximum(*max);
-    m_value_label->setText("Max set");
+bool DecimalSpinBoxTestWidget::set_minimum(const QString& minimum) {
+  if(auto min_value = get_value(minimum);
+      *min_value <= m_model->get_maximum()) {
+    m_model->set_minimum(*min_value);
+    return true;
   }
+  return false;
 }
 
-void DecimalSpinBoxTestWidget::on_increment_set() {
-  if(auto modifier = get_value(m_increment_input->text()); modifier) {
-    m_model->set_increment(get_modifier(
-      m_modifier_menu->get_current_item().value<QString>()), *modifier);
-    m_value_label->setText("Increment set");
-    update_increment_labels();
+QString DecimalSpinBoxTestWidget::get_maximum() const {
+  return QString::number(m_model->get_maximum());
+}
+
+bool DecimalSpinBoxTestWidget::set_maximum(const QString& maximum) {
+  if(auto max_value = get_value(maximum);
+      *max_value >= m_model->get_minimum()) {
+    m_model->set_maximum(*max_value);
+    return true;
   }
+  return false;
+}
+
+QString DecimalSpinBoxTestWidget::get_increment(
+    Qt::KeyboardModifiers modifiers) const {
+  return QString::number(m_model->get_increment(modifiers));
+}
+
+bool DecimalSpinBoxTestWidget::set_increment(Qt::KeyboardModifiers modifiers,
+    const QString& increment) {
+  if(auto increment_value = get_value(increment); increment_value) {
+    m_model->set_increment(modifiers, *increment_value);
+    return true;
+  }
+  return false;
+}
+
+connection DecimalSpinBoxTestWidget::connect_change_signal(
+    const ChangeSignal::slot_type& slot) const {
+  return m_change_signal.connect(slot);
 }

--- a/Applications/Spire/Source/UiViewer/DecimalSpinBoxTestWidget.cpp
+++ b/Applications/Spire/Source/UiViewer/DecimalSpinBoxTestWidget.cpp
@@ -46,7 +46,7 @@ DecimalSpinBoxTestWidget::DecimalSpinBoxTestWidget(QWidget* parent)
   auto container_widget = new QWidget(this);
   m_layout = new QGridLayout(container_widget);
   m_value_label = new QLabel(this);
-  m_layout->addWidget(m_value_label, 0, 1);
+  m_layout->addWidget(m_value_label, 0, 1, Qt::AlignCenter);
   auto initial_label = new QLabel(tr("Initial"), this);
   m_layout->addWidget(initial_label, 1, 0);
   m_initial_input = new TextInputWidget("0", this);

--- a/Applications/Spire/Source/UiViewer/SpinBoxAdapter.cpp
+++ b/Applications/Spire/Source/UiViewer/SpinBoxAdapter.cpp
@@ -1,0 +1,6 @@
+#include "Spire/UiViewer/SpinBoxAdapter.hpp"
+
+using namespace Spire;
+
+SpinBoxAdapter::SpinBoxAdapter(QWidget* parent)
+  : QWidget(parent) {}

--- a/Applications/Spire/Source/UiViewer/SpinBoxTestWidget.cpp
+++ b/Applications/Spire/Source/UiViewer/SpinBoxTestWidget.cpp
@@ -1,0 +1,156 @@
+#include "Spire/UiViewer/SpinBoxTestWidget.hpp"
+#include "Spire/Spire/Dimensions.hpp"
+#include "Spire/Spire/Utility.hpp"
+#include "Spire/Ui/FlatButton.hpp"
+
+using namespace boost;
+using namespace Spire;
+
+namespace {
+  const auto NO_MODIFIER = QString(QObject::tr("NoModifier"));
+  const auto SHIFT_MODIFIER = QString(QObject::tr("Shift"));
+  const auto CTRL_MODIFIER = QString(QObject::tr("Control"));
+  const auto CTRL_SHIFT_MODIFIER = QString(QObject::tr("Shift + Control"));
+
+  auto CONTROL_SIZE() {
+    static auto size = scale(100, 26);
+    return size;
+  }
+
+  Qt::KeyboardModifiers get_modifier(const QString& text) {
+    if(text == NO_MODIFIER) {
+      return Qt::NoModifier;
+    } else if(text == SHIFT_MODIFIER) {
+      return Qt::ShiftModifier;
+    } else if(text == CTRL_MODIFIER) {
+      return Qt::ControlModifier;
+    } else if(text == CTRL_SHIFT_MODIFIER) {
+      return Qt::ControlModifier | Qt::ShiftModifier;
+    }
+    return Qt::NoModifier;
+  }
+}
+
+SpinBoxTestWidget::SpinBoxTestWidget(SpinBoxAdapter* spin_box, QWidget* parent)
+    : QWidget(parent),
+      m_spin_box(spin_box) {
+  auto container_widget = new QWidget(this);
+  m_layout = new QGridLayout(container_widget);
+  m_value_label = new QLabel(this);
+  m_layout->addWidget(m_value_label, 0, 1, Qt::AlignCenter);
+  m_layout->addWidget(m_spin_box, 0, 0);
+  m_spin_box->connect_change_signal([=] (auto value) {
+    m_value_label->setText(value);
+  });
+  auto initial_label = new QLabel(tr("Initial"), this);
+  m_layout->addWidget(initial_label, 1, 0);
+  m_initial_input = new TextInputWidget("0", this);
+  m_initial_input->setFixedSize(CONTROL_SIZE());
+  connect(m_initial_input, &TextInputWidget::editingFinished, this,
+    &SpinBoxTestWidget::on_initial_set);
+  m_layout->addWidget(m_initial_input, 1, 1);
+  auto min_label = new QLabel(tr("Minimum"), this);
+  m_layout->addWidget(min_label, 2, 0);
+  m_min_input = new TextInputWidget("-1000", this);
+  m_min_input->setFixedSize(CONTROL_SIZE());
+  connect(m_min_input, &TextInputWidget::editingFinished, this,
+    &SpinBoxTestWidget::on_min_set);
+  m_layout->addWidget(m_min_input, 2, 1);
+  auto max_label = new QLabel(tr("Maximum"), this);
+  m_layout->addWidget(max_label, 3, 0);
+  m_max_input = new TextInputWidget("1000", this);
+  m_max_input->setFixedSize(CONTROL_SIZE());
+  connect(m_max_input, &TextInputWidget::editingFinished, this,
+    &SpinBoxTestWidget::on_max_set);
+  m_layout->addWidget(m_max_input, 3, 1);
+  m_modifier_menu = new StaticDropDownMenu({NO_MODIFIER, SHIFT_MODIFIER,
+    CTRL_MODIFIER, CTRL_SHIFT_MODIFIER}, this);
+  m_modifier_menu->setFixedSize(CONTROL_SIZE());
+  m_layout->addWidget(m_modifier_menu, 4, 0);
+  m_increment_input = new TextInputWidget("1", this);
+  m_increment_input->setFixedSize(CONTROL_SIZE());
+  connect(m_increment_input, &TextInputWidget::editingFinished, this,
+    &SpinBoxTestWidget::on_increment_set);
+  m_layout->addWidget(m_increment_input, 4, 1);
+  auto reset_button = make_flat_button(tr("Reset"), this);
+  reset_button->setFixedHeight(scale_height(26));
+  reset_button->connect_clicked_signal([=] { reset_spin_box(); });
+  m_layout->addWidget(reset_button, 5, 0, 1, 2);
+  auto no_label = new QLabel(NO_MODIFIER, this);
+  m_layout->addWidget(no_label, 6, 0);
+  m_no_increment_label = new QLabel(this);
+  m_layout->addWidget(m_no_increment_label, 6, 1);
+  auto shift_label = new QLabel(SHIFT_MODIFIER, this);
+  m_layout->addWidget(shift_label, 7, 0);
+  m_shift_increment_label = new QLabel(this);
+  m_layout->addWidget(m_shift_increment_label, 7, 1);
+  auto ctrl_label = new QLabel(CTRL_MODIFIER, this);
+  m_layout->addWidget(ctrl_label, 8, 0);
+  m_ctrl_increment_label = new QLabel(this);
+  m_layout->addWidget(m_ctrl_increment_label, 8, 1);
+  auto shift_ctrl_label = new QLabel(CTRL_SHIFT_MODIFIER, this);
+  m_layout->addWidget(shift_ctrl_label, 9, 0);
+  m_ctrl_shift_increment_label = new QLabel(this);
+  m_layout->addWidget(m_ctrl_shift_increment_label, 9, 1);
+  reset_spin_box();
+  m_value_label->setText(m_initial_input->text());
+}
+
+void SpinBoxTestWidget::reset_spin_box() {
+  if(m_spin_box->reset(m_initial_input->text(), m_min_input->text(),
+      m_max_input->text(), m_increment_input->text())) {
+    update_increment_labels();
+    m_change_connection = m_spin_box->connect_change_signal([=] (auto value) {
+      m_value_label->setText(value);
+    });
+    m_spin_box->setFocus();
+    m_value_label->setText(tr("Reset Successful"));
+  } else {
+    m_value_label->setText(tr("Failed"));
+  }
+}
+
+void SpinBoxTestWidget::update_increment_labels() {
+  m_no_increment_label->setText(m_spin_box->get_increment(Qt::NoModifier));
+  m_shift_increment_label->setText(m_spin_box->get_increment(
+    Qt::ShiftModifier));
+  m_ctrl_increment_label->setText(m_spin_box->get_increment(
+    Qt::ControlModifier));
+  m_ctrl_shift_increment_label->setText(m_spin_box->get_increment(
+    Qt::ControlModifier | Qt::ShiftModifier));
+}
+
+void SpinBoxTestWidget::on_initial_set() {
+  if(m_spin_box->set_initial(m_initial_input->text())) {
+    m_value_label->setText("Initial set");
+  } else {
+    m_value_label->setText(tr("Failed"));
+  }
+}
+
+void SpinBoxTestWidget::on_min_set() {
+  if(m_spin_box->set_minimum(m_min_input->text())) {
+    m_value_label->setText("Min set");
+  } else {
+    m_value_label->setText(tr("Failed"));
+  }
+}
+
+void SpinBoxTestWidget::on_max_set() {
+  if(m_spin_box->set_maximum(m_max_input->text())) {
+    m_value_label->setText("Max set");
+  } else {
+    m_value_label->setText(tr("Failed"));
+  }
+}
+
+void SpinBoxTestWidget::on_increment_set() {
+  if(m_spin_box->set_increment(get_modifier(
+      m_modifier_menu->get_current_item().value<QString>()),
+      m_increment_input->text())) {
+    m_value_label->setText("Increment set");
+    update_increment_labels();
+  } else {
+    m_value_label->setText(tr("Failed"));
+  }
+}

--- a/Applications/Spire/Source/UiViewer/UiViewerWindow.cpp
+++ b/Applications/Spire/Source/UiViewer/UiViewerWindow.cpp
@@ -6,6 +6,7 @@
 #include "Spire/UiViewer/ColorSelectorButtonTestWidget.hpp"
 #include "Spire/UiViewer/DecimalSpinBoxTestWidget.hpp"
 #include "Spire/UiViewer/FlatButtonTestWidget.hpp"
+#include "Spire/UiViewer/SpinBoxTestWidget.hpp"
 
 using namespace Spire;
 
@@ -50,7 +51,8 @@ UiViewerWindow::UiViewerWindow(QWidget* parent)
   m_layout->addWidget(m_widget_list);
   add_test_widget(tr("ColorSelectorButton"),
     new ColorSelectorButtonTestWidget(this));
-  add_test_widget(tr("DecimalSpinBox"), new DecimalSpinBoxTestWidget(this));
+  add_test_widget(tr("DecimalSpinBox"), new SpinBoxTestWidget(
+    new DecimalSpinBoxTestWidget(this), this));
   add_test_widget(tr("FlatButton"), new FlatButtonTestWidget(this));
   m_widget_list->setCurrentRow(0);
 }

--- a/Applications/Spire/Source/UiViewer/UiViewerWindow.cpp
+++ b/Applications/Spire/Source/UiViewer/UiViewerWindow.cpp
@@ -11,7 +11,7 @@ using namespace Spire;
 
 UiViewerWindow::UiViewerWindow(QWidget* parent)
     : Window(parent) {
-  setMinimumSize(scale(500, 300));
+  setMinimumSize(scale(500, 325));
   setWindowTitle(tr("UI Viewer"));
   set_svg_icon(":/Icons/spire-icon-black.svg", ":/Icons/spire-icon-grey.svg");
   setWindowIcon(QIcon(":/Icons/spire-icon-256x256.png"));

--- a/Applications/Spire/Source/UiViewer/UiViewerWindow.cpp
+++ b/Applications/Spire/Source/UiViewer/UiViewerWindow.cpp
@@ -4,6 +4,7 @@
 #include "Spire/Spire/Dimensions.hpp"
 #include "Spire/Spire/Utility.hpp"
 #include "Spire/UiViewer/ColorSelectorButtonTestWidget.hpp"
+#include "Spire/UiViewer/DecimalSpinBoxTestWidget.hpp"
 #include "Spire/UiViewer/FlatButtonTestWidget.hpp"
 
 using namespace Spire;
@@ -49,6 +50,7 @@ UiViewerWindow::UiViewerWindow(QWidget* parent)
   m_layout->addWidget(m_widget_list);
   add_test_widget(tr("ColorSelectorButton"),
     new ColorSelectorButtonTestWidget(this));
+  add_test_widget(tr("DecimalSpinBox"), new DecimalSpinBoxTestWidget(this));
   add_test_widget(tr("FlatButton"), new FlatButtonTestWidget(this));
   m_widget_list->setCurrentRow(0);
 }


### PR DESCRIPTION
I tried to separate the layout of the spin box tester from the spin box itself so it could be reused by the other spin box types, without complicating the tests with the introduction of the layout.

There is some issues with increments >= 100 (likely caused by bugs in converting Reals to strings), but this should be fixed in the other PR I have for the spin box fix.