### PR TITLE
Prevent first row editors from being moved twice when updateEditorGeo…

### DIFF
--- a/Applications/Spire/Source/KeyBindings/KeyBindingItemDelegate.cpp
+++ b/Applications/Spire/Source/KeyBindings/KeyBindingItemDelegate.cpp
@@ -32,12 +32,13 @@ void KeyBindingItemDelegate::setEditorData(QWidget* editor,
 
 void KeyBindingItemDelegate::updateEditorGeometry(QWidget* editor,
     const QStyleOptionViewItem& option, const QModelIndex& index) const {
-  editor->move(option.rect.topLeft());
-  editor->resize(option.rect.size());
   if(index.row() == 0) {
     auto rect = option.rect.translated(0, 1);
     editor->move(rect.topLeft());
     editor->resize(rect.width(), rect.height() - 1);
+  } else {
+    editor->move(option.rect.topLeft());
+    editor->resize(option.rect.size());
   }
   auto table = reinterpret_cast<QTableView*>(parent());
   if(table->horizontalHeader()->visualIndex(index.column()) == 0) {


### PR DESCRIPTION
Added a KeyBindingsUiTester-FirstRowJitter demo.