### PR TITLE
Security window fix

### DIFF
--- a/Applications/Spire/Source/SecurityInput/SecurityInputDialog.cpp
+++ b/Applications/Spire/Source/SecurityInput/SecurityInputDialog.cpp
@@ -132,9 +132,9 @@ void SecurityInputDialog::showEvent(QShowEvent* event) {
 }
 
 void SecurityInputDialog::reject_dialog() {
+  m_security_line_edit->findChild<DropDownList*>()->hide();
   disconnect(m_security_line_edit,
     &SecurityInputLineEdit::editingFinished, nullptr, nullptr);
-  m_security_line_edit->close();
   reject();
 }
 

--- a/Applications/Spire/Source/SecurityInput/SecurityInputDialog.cpp
+++ b/Applications/Spire/Source/SecurityInput/SecurityInputDialog.cpp
@@ -134,6 +134,7 @@ void SecurityInputDialog::showEvent(QShowEvent* event) {
 void SecurityInputDialog::reject_dialog() {
   disconnect(m_security_line_edit,
     &SecurityInputLineEdit::editingFinished, nullptr, nullptr);
+  m_security_line_edit->close();
   reject();
 }
 

--- a/Applications/Spire/Source/Ui/DropDownList.cpp
+++ b/Applications/Spire/Source/Ui/DropDownList.cpp
@@ -254,9 +254,9 @@ void DropDownList::update_height() {
 }
 
 void DropDownList::on_item_selected(QVariant value, int index) {
+  hide();
   m_index_selected_signal(index);
   m_value_selected_signal(std::move(value));
-  hide();
 }
 
 void DropDownList::on_item_selected(QVariant value, DropDownItem* item) {


### PR DESCRIPTION
I updated the UiViewer build. These changes fix two related issues, which could previously be found by:

1. Selecting the SecurityWidget test widget.
2. Clicking the SecurityWidget to set the focus.
3. Typing 'm'.
and,
4a. Left mouse clicking on a security.
or,
4b. Clicking on the scroll bar.
5b. Pressing escape.

In both cases the SecurityInputDialog would close and the UiViewer window would be deactivated with another open, unrelated, window receiving focus. These changes just make sure the windows are closed in the reverse order that they were shown. Based on the Win32 messages I observed, the most likely cause was that the dialog window was closing first, then the drop down list, causing the main window's place in the "activation order" to be lost.