### PR TITLE
Name column updates

### DIFF
--- a/Applications/Spire/Include/Spire/KeyBindings/KeyBindingItemDelegate.hpp
+++ b/Applications/Spire/Include/Spire/KeyBindings/KeyBindingItemDelegate.hpp
@@ -9,6 +9,19 @@ namespace Spire {
   class KeyBindingItemDelegate : public QStyledItemDelegate {
     public:
 
+      //! Represents the state of the delegate's editor.
+      enum class EditorState {
+
+        //! The editor's input value has been accepted.
+        ACCEPTED,
+
+        //! The editor has been closed without submitting a value.
+        CANCELLED,
+
+        //! The editor has been closed and the cell's value should be deleted.
+        DELETED
+      };
+
       //! Constructs a KeyBindingsItemDelegate.
       /*
         \param parent The parent widget.
@@ -25,11 +38,15 @@ namespace Spire {
         const QStyleOptionViewItem& option,
         const QModelIndex& index) const override;
 
+      //! Returns the state of the delegate's editor.
+      EditorState get_editor_state() const;
+
     protected:
       void on_editing_finished();
       bool eventFilter(QObject* watched, QEvent* event) override;
 
     private:
+      EditorState m_editor_state;
       CustomVariantItemDelegate* m_item_delegate;
   };
 }

--- a/Applications/Spire/Include/Spire/KeyBindings/KeyBindingItemDelegate.hpp
+++ b/Applications/Spire/Include/Spire/KeyBindings/KeyBindingItemDelegate.hpp
@@ -9,7 +9,8 @@ namespace Spire {
   class KeyBindingItemDelegate : public QStyledItemDelegate {
     public:
 
-      //! Represents the state of the delegate's editor.
+      //! Represents the state of the delegate's editor when the editor was
+      //! closed.
       enum class EditorState {
 
         //! The editor's input value has been accepted.

--- a/Applications/Spire/Include/Spire/KeyBindings/KeyBindingItemDelegate.hpp
+++ b/Applications/Spire/Include/Spire/KeyBindings/KeyBindingItemDelegate.hpp
@@ -9,8 +9,7 @@ namespace Spire {
   class KeyBindingItemDelegate : public QStyledItemDelegate {
     public:
 
-      //! Represents the state of the delegate's editor when the editor was
-      //! closed.
+      //! Represents the state of the delegate's editor.
       enum class EditorState {
 
         //! The editor's input value has been accepted.

--- a/Applications/Spire/Include/Spire/Ui/TextInputWidget.hpp
+++ b/Applications/Spire/Include/Spire/Ui/TextInputWidget.hpp
@@ -9,16 +9,6 @@ namespace Spire {
   class TextInputWidget : public QLineEdit {
     public:
 
-      /** The styles available to render the TextInputWidget. */
-      enum class Style {
-
-        /** Render using the default style. */
-        DEFAULT,
-
-        /** Render using the table cell style. */
-        CELL
-      };
-
       //! Constructs a TextInputWidget with the default style.
       /*!
         \param parent The parent widget.
@@ -32,19 +22,10 @@ namespace Spire {
       */
       explicit TextInputWidget(QString text, QWidget* parent = nullptr);
 
-      //! Returns the left text padding.
-      int get_padding() const;
-
-      //! Sets the TextInputWidget's style.
-      void set_style(Style style);
-
     protected:
       void focusInEvent(QFocusEvent* event) override;
       void keyPressEvent(QKeyEvent* event) override;
       void paintEvent(QPaintEvent* event) override;
-
-    private:
-      int m_left_padding;
   };
 }
 

--- a/Applications/Spire/Source/KeyBindings/KeyBindingItemDelegate.cpp
+++ b/Applications/Spire/Source/KeyBindings/KeyBindingItemDelegate.cpp
@@ -10,6 +10,7 @@ using namespace Spire;
 
 KeyBindingItemDelegate::KeyBindingItemDelegate(QWidget* parent)
   : QStyledItemDelegate(parent),
+    m_editor_state(EditorState::ACCEPTED),
     m_item_delegate(new CustomVariantItemDelegate(this)) {}
 
 void KeyBindingItemDelegate::paint(QPainter* painter,
@@ -33,12 +34,13 @@ void KeyBindingItemDelegate::setEditorData(QWidget* editor,
 void KeyBindingItemDelegate::updateEditorGeometry(QWidget* editor,
     const QStyleOptionViewItem& option, const QModelIndex& index) const {
   if(index.row() == 0) {
-    auto rect = option.rect.translated(0, 1);
+    auto rect = option.rect.translated(-1, 0);
     editor->move(rect.topLeft());
-    editor->resize(rect.width(), rect.height() - 1);
+    editor->resize(rect.width() + 2, rect.height() + 1);
   } else {
-    editor->move(option.rect.topLeft());
-    editor->resize(option.rect.size());
+    auto rect = option.rect.translated(-1, -1);
+    editor->move(rect.topLeft());
+    editor->resize({rect.width() + 2, rect.height() + 2});
   }
   auto table = reinterpret_cast<QTableView*>(parent());
   if(table->horizontalHeader()->visualIndex(index.column()) == 0) {
@@ -47,7 +49,13 @@ void KeyBindingItemDelegate::updateEditorGeometry(QWidget* editor,
   }
 }
 
+KeyBindingItemDelegate::EditorState
+    KeyBindingItemDelegate::get_editor_state() const {
+  return m_editor_state;
+}
+
 void KeyBindingItemDelegate::on_editing_finished() {
+  m_editor_state = EditorState::ACCEPTED;
   auto editor = static_cast<QWidget*>(sender());
   editor->close();
 }
@@ -55,18 +63,37 @@ void KeyBindingItemDelegate::on_editing_finished() {
 bool KeyBindingItemDelegate::eventFilter(QObject* watched, QEvent* event) {
   if(event->type() == QEvent::KeyPress) {
     auto e = static_cast<QKeyEvent*>(event);
-    if(e->key() == Qt::Key_Tab || e->key() == Qt::Key_Backtab) {
-      auto editor = static_cast<QWidget*>(watched);
-      Q_EMIT commitData(editor);
-      if(e->key() == Qt::Key_Tab) {
-        Q_EMIT closeEditor(editor, QAbstractItemDelegate::EditNextItem);
-      } else {
-        Q_EMIT closeEditor(editor, QAbstractItemDelegate::EditPreviousItem);
-      }
-      return true;
-    }
-    if(e->key() == Qt::Key_Enter || e->key() == Qt::Key_Return) {
-      return false;
+    switch(e->key()) {
+      case Qt::Key_Tab:
+      case Qt::Key_Backtab:
+        m_editor_state = EditorState::ACCEPTED;
+        {
+          auto editor = static_cast<QWidget*>(watched);
+          if(e->key() == Qt::Key_Tab) {
+            Q_EMIT closeEditor(editor, QAbstractItemDelegate::EditNextItem);
+          } else {
+            Q_EMIT closeEditor(editor, QAbstractItemDelegate::EditPreviousItem);
+          }
+        }
+        return true;
+      case Qt::Key_Enter:
+      case Qt::Key_Return:
+        return false;
+      case Qt::Key_Delete:
+        m_editor_state = EditorState::DELETED;
+        {
+          auto editor = static_cast<QWidget*>(watched);
+          Q_EMIT commitData(editor);
+          Q_EMIT closeEditor(editor);
+        }
+        return true;
+      case Qt::Key_Escape:
+        m_editor_state = EditorState::CANCELLED;
+        {
+          auto editor = static_cast<QWidget*>(watched);
+          Q_EMIT closeEditor(editor);
+        }
+        return true;
     }
   }
   return QStyledItemDelegate::eventFilter(watched, event);

--- a/Applications/Spire/Source/KeyBindings/NameItemDelegate.cpp
+++ b/Applications/Spire/Source/KeyBindings/NameItemDelegate.cpp
@@ -14,7 +14,6 @@ QWidget* NameItemDelegate::createEditor(QWidget* parent,
     const QStyleOptionViewItem& option, const QModelIndex& index) const {
   auto editor = new TextInputWidget(index.data().toString(),
     static_cast<QWidget*>(this->parent()));
-  editor->set_style(TextInputWidget::Style::CELL);
   connect(editor, &TextInputWidget::editingFinished,
     this, &NameItemDelegate::on_editing_finished);
   return editor;

--- a/Applications/Spire/Source/KeyBindings/NameItemDelegate.cpp
+++ b/Applications/Spire/Source/KeyBindings/NameItemDelegate.cpp
@@ -45,6 +45,11 @@ void NameItemDelegate::setEditorData(QWidget *editor,
 
 void NameItemDelegate::setModelData(QWidget* editor,
     QAbstractItemModel* model, const QModelIndex& index) const {
-  auto text = static_cast<QLineEdit*>(editor)->text().trimmed();
+  auto text = [&] {
+    if(get_editor_state() == EditorState::ACCEPTED) {
+      return QVariant(static_cast<TextInputWidget*>(editor)->text().trimmed());
+    }
+    return QVariant();
+  }();
   model->setData(index, text, Qt::DisplayRole);
 }

--- a/Applications/Spire/Source/KeyBindings/QuantityInputEditor.cpp
+++ b/Applications/Spire/Source/KeyBindings/QuantityInputEditor.cpp
@@ -10,7 +10,6 @@ QuantityInputEditor::QuantityInputEditor(int initial_value, QWidget* parent)
       m_initial_value(initial_value) {
   setContextMenuPolicy(Qt::NoContextMenu);
   setValidator(new QIntValidator(0, std::numeric_limits<int>::max(), this));
-  set_style(TextInputWidget::Style::CELL);
 }
 
 void QuantityInputEditor::keyPressEvent(QKeyEvent* event) {

--- a/Applications/Spire/Source/KeyBindings/QuantityItemDelegate.cpp
+++ b/Applications/Spire/Source/KeyBindings/QuantityItemDelegate.cpp
@@ -16,17 +16,22 @@ QWidget* QuantityItemDelegate::createEditor(QWidget* parent,
   auto editor = new QuantityInputEditor(
     static_cast<int>(index.data().value<Quantity>()),
     static_cast<QWidget*>(this->parent()));
-  connect(editor, &QLineEdit::editingFinished,
+  connect(editor, &TextInputWidget::editingFinished,
     this, &QuantityItemDelegate::on_editing_finished);
   return editor;
 }
 
 void QuantityItemDelegate::setModelData(QWidget* editor,
     QAbstractItemModel* model, const QModelIndex& index) const {
-  auto ok = false;
-  auto value = static_cast<QLineEdit*>(editor)->text().toInt(&ok);
-  if(ok) {
-    model->setData(index, QVariant::fromValue<Quantity>(value),
-      Qt::DisplayRole);
-  }
+  auto quantity = [&] {
+    if(get_editor_state() == EditorState::ACCEPTED) {
+      auto ok = false;
+      auto value = static_cast<TextInputWidget*>(editor)->text().toInt(&ok);
+      if(ok) {
+        return QVariant::fromValue<Quantity>(value);
+      }
+    }
+    return QVariant();
+  }();
+  model->setData(index, quantity, Qt::DisplayRole);
 }

--- a/Applications/Spire/Source/KeyBindings/SecurityInputItemDelegate.cpp
+++ b/Applications/Spire/Source/KeyBindings/SecurityInputItemDelegate.cpp
@@ -24,7 +24,12 @@ QWidget* SecurityInputItemDelegate::createEditor(QWidget* parent,
 
 void SecurityInputItemDelegate::setModelData(QWidget* editor,
     QAbstractItemModel* model, const QModelIndex& index) const {
-  auto line_edit = static_cast<SecurityInputLineEdit*>(editor);
-  model->setData(index,
-    QVariant::fromValue<Security>(line_edit->get_security()), Qt::DisplayRole);
+  auto security = [&] {
+    if(get_editor_state() == EditorState::ACCEPTED) {
+      return QVariant::fromValue(
+        static_cast<SecurityInputLineEdit*>(editor)->get_security());
+    }
+    return QVariant();
+  }();
+  model->setData(index, security, Qt::DisplayRole);
 }

--- a/Applications/Spire/Source/KeyBindings/SecurityInputItemDelegate.cpp
+++ b/Applications/Spire/Source/KeyBindings/SecurityInputItemDelegate.cpp
@@ -17,7 +17,6 @@ QWidget* SecurityInputItemDelegate::createEditor(QWidget* parent,
   auto editor = new SecurityInputLineEdit(index.data().value<Security>(),
     Ref<SecurityInputModel>(*m_model), false,
     static_cast<QWidget*>(this->parent()));
-  editor->set_style(TextInputWidget::Style::CELL);
   connect(editor, &SecurityInputLineEdit::editingFinished, this,
     &SecurityInputItemDelegate::on_editing_finished);
   return editor;

--- a/Applications/Spire/Source/Ui/TextInputWidget.cpp
+++ b/Applications/Spire/Source/Ui/TextInputWidget.cpp
@@ -9,17 +9,34 @@ using namespace Spire;
 namespace {
   const auto BORDER_SIZE = 1;
   const auto HORIZONTAL_MARGIN = 2;
+
+  auto PADDING() {
+    static auto padding = scale_width(8);
+    return padding;
+  }
 }
 
 TextInputWidget::TextInputWidget(QWidget* parent)
   : TextInputWidget({}, parent) {}
 
 TextInputWidget::TextInputWidget(QString text, QWidget* parent)
-    : QLineEdit(std::move(text), parent),
-      m_left_padding(0) {
+    : QLineEdit(std::move(text), parent) {
   setAttribute(Qt::WA_Hover);
   setContextMenuPolicy(Qt::NoContextMenu);
-  set_style(Style::DEFAULT);
+  setStyleSheet(QString(R"(
+    QLineEdit {
+      background-color: #FFFFFF;
+      border: %1px solid #C8C8C8 %2px solid #C8C8C8;
+      color: #000000;
+      font-family: Roboto;
+      font-size: %3px;
+      padding-left: %4px;
+    }
+
+    QLineEdit:focus {
+      border: %1px solid #4B23A0 %2px solid #4B23A0;
+    })").arg(scale_height(1)).arg(scale_width(1)).arg(scale_height(12))
+        .arg(PADDING()));
 }
 
 void TextInputWidget::focusInEvent(QFocusEvent* event) {
@@ -62,43 +79,8 @@ void TextInputWidget::paintEvent(QPaintEvent* event) {
   auto elided_text = metrics.elidedText(text(), Qt::ElideRight,
     width() - scale_width(16));
   painter.setPen(Qt::black);
-  auto text_rect = QRect(m_left_padding + BORDER_SIZE + HORIZONTAL_MARGIN,
+  auto text_rect = QRect(PADDING() + BORDER_SIZE + HORIZONTAL_MARGIN,
     BORDER_SIZE + ((height() - BORDER_SIZE - metrics.height()) / 2),
     width() - (2 * BORDER_SIZE) - (2 * HORIZONTAL_MARGIN), metrics.height());
   painter.drawText(text_rect, elided_text);
-}
-
-int TextInputWidget::get_padding() const {
-  return m_left_padding;
-}
-
-void TextInputWidget::set_style(Style style) {
-  if(style == Style::CELL) {
-    m_left_padding = scale_width(5);
-    setStyleSheet(QString(R"(
-      QLineEdit {
-        background-color: #FFFFFF;
-        border: none;
-        color: #000000;
-        font-family: Roboto;
-        font-size: %1px;
-        padding-left: %2px;
-      })").arg(scale_height(12)).arg(m_left_padding));
-  } else {
-    m_left_padding = scale_width(8);
-    setStyleSheet(QString(R"(
-      QLineEdit {
-        background-color: #FFFFFF;
-        border: %1px solid #C8C8C8 %2px solid #C8C8C8;
-        color: #000000;
-        font-family: Roboto;
-        font-size: %3px;
-        padding-left: %4px;
-      }
-
-      QLineEdit:focus {
-        border: %1px solid #4B23A0 %2px solid #4B23A0;
-      })").arg(scale_height(1)).arg(scale_width(1)).arg(scale_height(12))
-          .arg(m_left_padding));
-  }
 }


### PR DESCRIPTION
I updated the KeyBindings demo. This case was originally for the Name column, but the Security and Quantity columns use the TextInputWidget as a base, so they were relatively straightforward to update as well.

The addition of the EditorState member removes the need for the editor widgets themselves to need to know the intent of the user, because now they're either submitting a value or they're not, and it's up to the delegate to know the intent of the user.

The other columns' editors will be displayed slightly out of position until they're updated to use the new combo boxes, key sequence input, etc.