### PR TITLE
Restored previously removed event filter for TimeAndSalesTableView th…

### DIFF
--- a/Applications/Spire/Include/Spire/TimeAndSales/TimeAndSalesTableView.hpp
+++ b/Applications/Spire/Include/Spire/TimeAndSales/TimeAndSalesTableView.hpp
@@ -34,6 +34,7 @@ namespace Spire {
       void set_properties(const TimeAndSalesProperties& properties);
 
     protected:
+      bool eventFilter(QObject* watched, QEvent* event) override;
       void resizeEvent(QResizeEvent* event) override;
       void showEvent(QShowEvent* event) override;
 

--- a/Applications/Spire/Include/Spire/TimeAndSales/TimeAndSalesTableView.hpp
+++ b/Applications/Spire/Include/Spire/TimeAndSales/TimeAndSalesTableView.hpp
@@ -34,7 +34,6 @@ namespace Spire {
       void set_properties(const TimeAndSalesProperties& properties);
 
     protected:
-      bool eventFilter(QObject* watched, QEvent* event) override;
       void resizeEvent(QResizeEvent* event) override;
       void showEvent(QShowEvent* event) override;
 

--- a/Applications/Spire/Source/TimeAndSales/TimeAndSalesTableView.cpp
+++ b/Applications/Spire/Source/TimeAndSales/TimeAndSalesTableView.cpp
@@ -90,7 +90,6 @@ TimeAndSalesTableView::TimeAndSalesTableView(QWidget* parent)
     })");
   m_table->setItemDelegate(new ItemPaddingDelegate(scale_width(5),
     new CustomVariantItemDelegate(), this));
-  m_table->installEventFilter(this);
   m_layout->addWidget(m_table);
   setWidget(main_widget);
 }
@@ -130,13 +129,6 @@ void TimeAndSalesTableView::set_properties(
   if(m_table->model()->rowCount() > 0) {
     update_table_height(m_table->model()->rowCount());
   }
-}
-
-bool TimeAndSalesTableView::eventFilter(QObject* watched, QEvent* event) {
-  if(watched == m_table && event->type() == QEvent::Paint) {
-    m_header->viewport()->update();
-  }
-  return ScrollArea::eventFilter(watched, event);
 }
 
 void TimeAndSalesTableView::resizeEvent(QResizeEvent* event) {
@@ -215,6 +207,7 @@ void TimeAndSalesTableView::on_vertical_slider_value_changed(
   }
   m_model->set_row_visible(m_table->rowAt(
     m_table->visibleRegion().boundingRect().bottom()));
+  m_header->viewport()->update();
 }
 
 void TimeAndSalesTableView::on_rows_about_to_be_inserted(

--- a/Applications/Spire/Source/TimeAndSales/TimeAndSalesTableView.cpp
+++ b/Applications/Spire/Source/TimeAndSales/TimeAndSalesTableView.cpp
@@ -90,6 +90,7 @@ TimeAndSalesTableView::TimeAndSalesTableView(QWidget* parent)
     })");
   m_table->setItemDelegate(new ItemPaddingDelegate(scale_width(5),
     new CustomVariantItemDelegate(), this));
+  m_table->installEventFilter(this);
   m_layout->addWidget(m_table);
   setWidget(main_widget);
 }
@@ -129,6 +130,13 @@ void TimeAndSalesTableView::set_properties(
   if(m_table->model()->rowCount() > 0) {
     update_table_height(m_table->model()->rowCount());
   }
+}
+
+bool TimeAndSalesTableView::eventFilter(QObject* watched, QEvent* event) {
+  if(watched == m_table && event->type() == QEvent::Paint) {
+    m_header->viewport()->update();
+  }
+  return ScrollArea::eventFilter(watched, event);
 }
 
 void TimeAndSalesTableView::resizeEvent(QResizeEvent* event) {


### PR DESCRIPTION
I added a TimeAndSalesUiTester-FlickerFix demo. The TimeAndSalesUiTester-CursorResizeRegion demo can be used to see the original flicker issue.

To reiterate the issue:

1. Run the TimeAndSalesUiTester-CursorResizeRegion demo.
2. Type 'm' and select a security.
3. Drag the vertical scroll bar up and down quickly.
4. The table's header will disappear and reappear, causing a 'flicker' effect.

The more data there is in the table, the more obvious the issue becomes, so it helps to scroll to the bottom of the table a few times first to have the table load more test data.