### PR TITLE
DecimalBox Horizontal Scroll Behaviour

### DIFF
--- a/Applications/Spire/Include/Spire/Ui/DecimalBox.hpp
+++ b/Applications/Spire/Include/Spire/Ui/DecimalBox.hpp
@@ -143,6 +143,9 @@ namespace Styles {
       void keyPressEvent(QKeyEvent* event) override;
       void resizeEvent(QResizeEvent* event) override;
       void wheelEvent(QWheelEvent* event) override;
+      bool event(QEvent* event) override;
+      bool nativeEvent(const QByteArray& eventType, void* message,
+        long* result) override;
 
     private:
       struct DecimalToTextModel;
@@ -156,6 +159,7 @@ namespace Styles {
       QRegExp m_validator;
       Button* m_up_button;
       Button* m_down_button;
+      Qt::Orientation m_mouse_wheel_orientation;
       boost::signals2::scoped_connection m_current_connection;
       boost::signals2::scoped_connection m_submit_connection;
       boost::signals2::scoped_connection m_reject_connection;

--- a/Applications/Spire/Include/Spire/Ui/DecimalBox.hpp
+++ b/Applications/Spire/Include/Spire/Ui/DecimalBox.hpp
@@ -143,7 +143,6 @@ namespace Styles {
       void keyPressEvent(QKeyEvent* event) override;
       void resizeEvent(QResizeEvent* event) override;
       void wheelEvent(QWheelEvent* event) override;
-      bool event(QEvent* event) override;
       bool nativeEvent(const QByteArray& eventType, void* message,
         long* result) override;
 

--- a/Applications/Spire/Source/Ui/DecimalBox.cpp
+++ b/Applications/Spire/Source/Ui/DecimalBox.cpp
@@ -401,7 +401,7 @@ void DecimalBox::wheelEvent(QWheelEvent* event) {
   if(hasFocus() && !is_read_only()) {
     auto angle_delta = [&] {
       if(m_mouse_wheel_orientation == Qt::Horizontal) {
-        return -event->angleDelta().x();
+        return 0;
       } else if(event->modifiers().testFlag(Qt::AltModifier)) {
         return event->angleDelta().x();
       } else {
@@ -410,7 +410,7 @@ void DecimalBox::wheelEvent(QWheelEvent* event) {
     }();
     if(angle_delta > 0) {
       increment();
-    } else {
+    } else if(angle_delta < 0) {
       decrement();
     }
   }

--- a/Applications/Spire/Source/Ui/DecimalBox.cpp
+++ b/Applications/Spire/Source/Ui/DecimalBox.cpp
@@ -321,6 +321,8 @@ DecimalBox::DecimalBox(std::shared_ptr<DecimalModel> model,
       m_submission(m_model->get_current()),
       m_modifiers(std::move(modifiers)),
       m_mouse_wheel_orientation(Qt::Vertical) {
+  setAttribute(Qt::WA_NativeWindow);
+  setAttribute(Qt::WA_DontCreateNativeAncestors);
   auto layout = new QHBoxLayout(this);
   layout->setContentsMargins({});
   m_text_box = new TextBox(m_adaptor_model, this);
@@ -413,13 +415,6 @@ void DecimalBox::wheelEvent(QWheelEvent* event) {
     }
   }
   QWidget::wheelEvent(event);
-}
-
-bool DecimalBox::event(QEvent* event) {
-  if(event->type() == QEvent::Show) {
-    setAttribute(Qt::WA_NativeWindow);
-  }
-  return QWidget::event(event);
 }
 
 bool DecimalBox::nativeEvent(const QByteArray& eventType, void* message,

--- a/Applications/Spire/Source/Ui/DecimalBox.cpp
+++ b/Applications/Spire/Source/Ui/DecimalBox.cpp
@@ -430,7 +430,7 @@ bool DecimalBox::nativeEvent(const QByteArray& eventType, void* message,
   } else if(msg->message == WM_MOUSEWHEEL) {
     m_mouse_wheel_orientation = Qt::Vertical;
   }
-  return false;
+  return QWidget::nativeEvent(eventType, message, result);
 }
 
 void DecimalBox::decrement() {


### PR DESCRIPTION
This PR is to try to solve the task of "DecimalBox Horizontal Scroll Behaviour" posted on Asana.

Below are some notes of this fix:

Qt changes Alt+vertical wheel mouse events to horizontal wheel mouse events. I guess Qt wants to simulate horizontal wheel mouse events using Alt+vertical wheel mouse events. Even though I didn’t find any explanation about it from Qt documentation, I found the code snippet below from Qt which could prove my guess.

const QPoint angleDelta = (msg.message == WM_MOUSEHWHEEL || (keyModifiers & Qt::AltModifier)) ?
                QPoint(delta, 0) : QPoint(0, delta);

When the Alt key is pressed, we can’t distinguish whether a wheel event is emitted by rotating horizontally or vertically. 

 In order to solve this problem, I have to catch native wheel events like WM_MOUSEWHEEL and WM_MOUSEHWHEEL to determine in which direction the mouse wheel is rotated. The disadvantage of this approach is that it breaks compatibility. Except this way, I don’t have a better way to solve it.
