### PR TITLE
Removed mousePressEvent override from the TimeAndSalesPropertiesDialo…

### DIFF
--- a/Applications/Spire/Include/Spire/TimeAndSales/TimeAndSalesPropertiesDialog.hpp
+++ b/Applications/Spire/Include/Spire/TimeAndSales/TimeAndSalesPropertiesDialog.hpp
@@ -48,10 +48,6 @@ namespace Spire {
       boost::signals2::connection connect_save_default_signal(
         const SaveDefaultSignal::slot_type& slot) const;
 
-    protected:
-      void mousePressEvent(QMouseEvent* event) override;
-      void showEvent(QShowEvent* event) override;
-
     private:
       mutable ApplySignal m_apply_signal;
       mutable ApplyAllSignal m_apply_all_signal;

--- a/Applications/Spire/Source/TimeAndSales/TimeAndSalesPropertiesDialog.cpp
+++ b/Applications/Spire/Source/TimeAndSales/TimeAndSalesPropertiesDialog.cpp
@@ -205,17 +205,6 @@ connection TimeAndSalesPropertiesDialog::connect_save_default_signal(
   return m_save_default_signal.connect(slot);
 }
 
-void TimeAndSalesPropertiesDialog::mousePressEvent(QMouseEvent* event) {
-  setFocus();
-}
-
-void TimeAndSalesPropertiesDialog::showEvent(QShowEvent* event) {
-  m_band_list->setFocus();
-  auto parent_geometry = static_cast<QWidget*>(parent())->geometry();
-  move(parent_geometry.center().x() - (width() / 2),
-    parent_geometry.center().y() - (height() / 2));
-}
-
 void TimeAndSalesPropertiesDialog::set_band_color(const QColor& color) {
   auto index = m_band_list->currentIndex().row();
   auto band = static_cast<PriceRange>(index);


### PR DESCRIPTION
I removed the code to center the properties dialog because it should most likely be the responsibility of the Dialog class itself.