### PR TITLE
OverlayPanel can be closed on escape key press.

### DIFF
--- a/Applications/Spire/Include/Spire/Ui/OverlayPanel.hpp
+++ b/Applications/Spire/Include/Spire/Ui/OverlayPanel.hpp
@@ -60,6 +60,7 @@ namespace Spire {
       void showEvent(QShowEvent* event) override;
       void closeEvent(QCloseEvent* event) override;
       bool event(QEvent* event) override;
+      void keyPressEvent(QKeyEvent* event) override;
 
     private:
       QWidget* m_body;

--- a/Applications/Spire/Source/Ui/OverlayPanel.cpp
+++ b/Applications/Spire/Source/Ui/OverlayPanel.cpp
@@ -142,9 +142,9 @@ bool OverlayPanel::event(QEvent* event) {
 void OverlayPanel::keyPressEvent(QKeyEvent* event) {
   if(event->key() == Qt::Key_Escape && !m_is_closed) {
     fade(true);
-  } else {
-    QWidget::keyPressEvent(event);
+    return;
   }
+  QWidget::keyPressEvent(event);
 }
 
 void OverlayPanel::fade(bool reverse) {

--- a/Applications/Spire/Source/Ui/OverlayPanel.cpp
+++ b/Applications/Spire/Source/Ui/OverlayPanel.cpp
@@ -139,6 +139,16 @@ bool OverlayPanel::event(QEvent* event) {
   return QWidget::event(event);
 }
 
+void OverlayPanel::keyPressEvent(QKeyEvent* event) {
+  if(event->key() == Qt::Key_Escape) {
+    if(!m_is_closed) {
+      fade(true);
+    }
+  } else {
+    QWidget::keyPressEvent(event);
+  }
+}
+
 void OverlayPanel::fade(bool reverse) {
   auto animation = new QPropertyAnimation(this, "windowOpacity");
   animation->setDuration(FADE_SPEED_MS);

--- a/Applications/Spire/Source/Ui/OverlayPanel.cpp
+++ b/Applications/Spire/Source/Ui/OverlayPanel.cpp
@@ -140,10 +140,8 @@ bool OverlayPanel::event(QEvent* event) {
 }
 
 void OverlayPanel::keyPressEvent(QKeyEvent* event) {
-  if(event->key() == Qt::Key_Escape) {
-    if(!m_is_closed) {
-      fade(true);
-    }
+  if(event->key() == Qt::Key_Escape && !m_is_closed) {
+    fade(true);
   } else {
     QWidget::keyPressEvent(event);
   }

--- a/Applications/Spire/Source/UiViewer/StandardUiProfiles.cpp
+++ b/Applications/Spire/Source/UiViewer/StandardUiProfiles.cpp
@@ -665,7 +665,7 @@ UiProfile Spire::make_overlay_panel_profile() {
     make_standard_enum_property("positioning", positioning_property));
   auto profile = UiProfile(QString::fromUtf8("OverlayPanel"), properties,
     [=] (auto& profile) {
-      auto button = make_label_button("Click me");
+      auto button = make_label_button(QString::fromUtf8("Click me"));
       auto close_on_blur_connection = std::make_shared<scoped_connection>();
       auto positioning_connection = std::make_shared<scoped_connection>();
       auto panel = static_cast<OverlayPanel*>(nullptr);
@@ -681,7 +681,7 @@ UiProfile Spire::make_overlay_panel_profile() {
           scale_width(1), scale_height(1), scale_width(1), scale_height(1));
         auto title_layout = new QHBoxLayout();
         title_layout->setSpacing(scale_width(3));
-        auto title_name = new QLabel("Filter Date");
+        auto title_name = new QLabel(QString::fromUtf8("Filter Date"));
         title_layout->addWidget(title_name);
         auto close_button =
           make_icon_button(imageFromSvg(":/Icons/close.svg", scale(26, 26)));
@@ -697,14 +697,18 @@ UiProfile Spire::make_overlay_panel_profile() {
         content_layout->setSpacing(scale_width(5));
         content_layout->setContentsMargins(
           {scale_width(4), scale_height(4), scale_width(4), scale_height(4)});
-        content_layout->addWidget(new QLabel("Start Date:"), 0, 0);
+        content_layout->addWidget(new QLabel(QString::fromUtf8("Start Date:")),
+          0, 0);
         auto text_box1 = new TextBox();
         text_box1->setFixedSize(scale(120, 26));
         content_layout->addWidget(text_box1, 0, 1);
-        content_layout->addWidget(new QLabel("End Date:"), 1, 0);
+        content_layout->addWidget(new QLabel(QString::fromUtf8("End Date:")), 1,
+          0);
         auto text_box2 = new TextBox();
         text_box2->setFixedSize(scale(120, 26));
         content_layout->addWidget(text_box2, 1, 1);
+        content_layout->addWidget(make_label_button(QString::fromUtf8("Reset")),
+          2, 1);
         container_layout->addLayout(content_layout);
         panel = new OverlayPanel(body, button);
         auto& close_on_blur =


### PR DESCRIPTION
The TextBox can deal with ESC event, so when the TextBox gets focus, the panel can't be closed.