### PR TITLE
The ScrollableLayer uses a mask over its transparent region to allow …

### DIFF
--- a/Applications/Spire/Include/Spire/Ui/ScrollBox.hpp
+++ b/Applications/Spire/Include/Spire/Ui/ScrollBox.hpp
@@ -65,6 +65,7 @@ namespace Spire {
       bool eventFilter(QObject* watched, QEvent* event) override;
       void keyPressEvent(QKeyEvent* event) override;
       void resizeEvent(QResizeEvent* event) override;
+      void wheelEvent(QWheelEvent* event) override;
 
     private:
       QWidget* m_body;

--- a/Applications/Spire/Include/Spire/Ui/ScrollableLayer.hpp
+++ b/Applications/Spire/Include/Spire/Ui/ScrollableLayer.hpp
@@ -3,6 +3,8 @@
 #include <QWidget>
 #include "Spire/Ui/Ui.hpp"
 
+class QSpacerItem;
+
 namespace Spire {
 
   /**
@@ -28,9 +30,16 @@ namespace Spire {
 
       void wheelEvent(QWheelEvent* event) override;
 
+    protected:
+      bool eventFilter(QObject* watched, QEvent* event) override;
+      void resizeEvent(QResizeEvent* event) override;
+
     private:
+      QSpacerItem* m_transparent_spacer;
       ScrollBar* m_vertical_scroll_bar;
       ScrollBar* m_horizontal_scroll_bar;
+
+      void update_mask();
   };
 }
 

--- a/Applications/Spire/Source/Ui/ScrollBox.cpp
+++ b/Applications/Spire/Source/Ui/ScrollBox.cpp
@@ -94,6 +94,10 @@ void ScrollBox::resizeEvent(QResizeEvent* event) {
   update_ranges();
 }
 
+void ScrollBox::wheelEvent(QWheelEvent* event) {
+  m_scrollable_layer->wheelEvent(event);
+}
+
 void ScrollBox::on_vertical_scroll(int position) {
   m_body->move(m_body->pos().x(), -position);
 }

--- a/Applications/Spire/Source/Ui/ScrollableLayer.cpp
+++ b/Applications/Spire/Source/Ui/ScrollableLayer.cpp
@@ -9,15 +9,17 @@ using namespace Spire;
 using namespace Spire::Styles;
 
 ScrollableLayer::ScrollableLayer(QWidget* parent)
-  : QWidget(parent),
-    m_vertical_scroll_bar(new ScrollBar(Qt::Orientation::Vertical, this)),
-    m_horizontal_scroll_bar(new ScrollBar(Qt::Orientation::Horizontal, this)) {
+    : QWidget(parent),
+      m_vertical_scroll_bar(new ScrollBar(Qt::Orientation::Vertical, this)),
+      m_horizontal_scroll_bar(
+        new ScrollBar(Qt::Orientation::Horizontal, this)) {
   auto layout = new QGridLayout(this);
   layout->setContentsMargins({});
   layout->setSpacing(0);
   layout->setColumnStretch(0, 1);
-  layout->addItem(new QSpacerItem(
-    1, 1, QSizePolicy::Expanding, QSizePolicy::Expanding), 0, 0);
+  m_transparent_spacer =
+    new QSpacerItem(1, 1, QSizePolicy::Expanding, QSizePolicy::Expanding);
+  layout->addItem(m_transparent_spacer, 0, 0);
   layout->addWidget(m_vertical_scroll_bar, 0, 1);
   layout->addWidget(m_horizontal_scroll_bar, 1, 0);
   auto corner_box = new Box(nullptr);
@@ -26,6 +28,7 @@ ScrollableLayer::ScrollableLayer(QWidget* parent)
   set_style(*corner_box, std::move(style));
   corner_box->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
   layout->addWidget(corner_box, 1, 1);
+  update_mask();
 }
 
 ScrollBar& ScrollableLayer::get_vertical_scroll_bar() {
@@ -74,4 +77,21 @@ void ScrollableLayer::wheelEvent(QWheelEvent* event) {
   } else if(event->angleDelta().x() > 0) {
     scroll_line_up(*m_horizontal_scroll_bar);
   }
+}
+
+bool ScrollableLayer::eventFilter(QObject* watched, QEvent* event) {
+  if((watched == m_vertical_scroll_bar || watched == m_horizontal_scroll_bar) &&
+      (event->type() == QEvent::Resize || event->type() == QEvent::Show ||
+      event->type() == QEvent::Hide)) {
+    update_mask();
+  }
+  return QWidget::eventFilter(watched, event);
+}
+
+void ScrollableLayer::resizeEvent(QResizeEvent* event) {
+  update_mask();
+}
+
+void ScrollableLayer::update_mask() {
+  setMask(QPolygon(geometry()).subtracted(m_transparent_spacer->geometry()));
 }


### PR DESCRIPTION
…all mouse events to pass through to the background. This eliminates a bug where the ScrollBox's body was not receiving mouse events because the ScrollableLayer was swallowing them all up.