### PR TITLE
When both scrollbars are no longer visible, the ScrollableLayer's mas…

### DIFF
--- a/Applications/Spire/Source/Ui/ScrollableLayer.cpp
+++ b/Applications/Spire/Source/Ui/ScrollableLayer.cpp
@@ -95,5 +95,12 @@ void ScrollableLayer::resizeEvent(QResizeEvent* event) {
 }
 
 void ScrollableLayer::update_mask() {
-  setMask(QPolygon(geometry()).subtracted(m_transparent_spacer->geometry()));
+  auto region =
+    QPolygon(geometry()).subtracted(m_transparent_spacer->geometry());
+  if(region.isEmpty()) {
+    setAttribute(Qt::WA_TransparentForMouseEvents);
+  } else {
+    setAttribute(Qt::WA_TransparentForMouseEvents, false);
+    setMask(region);
+  }
 }


### PR DESCRIPTION
…king region would result in an empty QPolygon, meaning that ScrollableLayer would consume all mouse events when in fact it should be ignoring all mouse events. To fix this, when an empty region is computed, the ScrollableLayer will set the TransparentForMouseEvents flag so that all mouse events are ignored.