### PR TITLE
When the Stylist handles the EnableSignal of some component within it…

### DIFF
--- a/Applications/Spire/Include/Spire/Styles/Stylist.hpp
+++ b/Applications/Spire/Include/Spire/Styles/Stylist.hpp
@@ -196,6 +196,7 @@ namespace Spire::Styles {
         std::type_index, std::unique_ptr<BaseEvaluatorEntry>> m_evaluators;
       std::type_index m_evaluated_property;
       std::chrono::time_point<std::chrono::steady_clock> m_last_frame;
+      bool m_is_handling_enabled_signal;
       QMetaObject::Connection m_animation_connection;
 
       Stylist(QWidget& parent, boost::optional<PseudoElement> pseudo_element);

--- a/Applications/Spire/Source/Ui/TextBox.cpp
+++ b/Applications/Spire/Source/Ui/TextBox.cpp
@@ -165,6 +165,9 @@ bool TextBox::is_read_only() const {
 }
 
 void TextBox::set_read_only(bool read_only) {
+  if(m_line_edit->isReadOnly() == read_only) {
+    return;
+  }
   m_line_edit->setReadOnly(read_only);
   m_line_edit->setCursorPosition(0);
   if(read_only) {


### PR DESCRIPTION
…s reach, it will in turn signal the EnableSignal. This is done to fix a bug where if a component A's style depends on B, and B's style depends on C, then a change in C will result in an update to B's style, but will not update A's style. For a concrete example, the DecimalBox's step buttons depend on DecimalBox's ReadOnly state, and DecimalBox's ReadOnly state in turn depends on TextBox's ReadOnly state, and so when TextBox's ReadOnly state was updated, it did not propagate to the step buttons a change in style.

TextBox::set_read_only is a no-op if read_only == TextBox::is_read_only().