### PR TITLE
Every Box was using the same objectName which causes Boxes that a des…

### DIFF
--- a/Applications/Spire/Source/Ui/Box.cpp
+++ b/Applications/Spire/Source/Ui/Box.cpp
@@ -40,7 +40,7 @@ Box::Box(QWidget* body, QWidget* parent)
     : QWidget(parent),
       m_body(body),
       m_styles([=] { commit_style(); }) {
-  setObjectName("Box");
+  setObjectName(QString("0x%1").arg(reinterpret_cast<std::intptr_t>(this)));
   if(m_body) {
     m_container = new QWidget(this);
     auto layout = new QHBoxLayout(m_container);
@@ -149,8 +149,8 @@ void Box::resizeEvent(QResizeEvent* event) {
 
 void Box::commit_style() {
   auto stylesheet = QString(
-    R"(#Box {
-        border-style: solid;)");
+    R"(#0x%1 {
+        border-style: solid;)").arg(reinterpret_cast<std::intptr_t>(this));
   m_styles.write(stylesheet);
   if(stylesheet != styleSheet()) {
     setStyleSheet(stylesheet);


### PR DESCRIPTION
…cendants of other Boxes to inherit their ancestors styling. This is not the expected behavior for styling many components. To fix this, every Box is given a unique name based on its memory address.