### PR TITLE
Initialized ScrollBox's horizontal and vertical display policies to S…

### DIFF
--- a/Applications/Spire/Source/Ui/ScrollBox.cpp
+++ b/Applications/Spire/Source/Ui/ScrollBox.cpp
@@ -10,7 +10,9 @@ using namespace Spire::Styles;
 
 ScrollBox::ScrollBox(QWidget* body, QWidget* parent)
     : QWidget(parent),
-      m_body(body) {
+      m_body(body),
+      m_horizontal_display_policy(DisplayPolicy::ALWAYS),
+      m_vertical_display_policy(DisplayPolicy::ALWAYS) {
   auto layers = new LayeredWidget(this);
   auto viewport = new QWidget();
   m_body->installEventFilter(this);


### PR DESCRIPTION
…crollBox::DisplayPolicy::ALWAYS by default. Prior to this they were uninitialized resulting in undefined behavior.