### PR TITLE
Remove the conversion to QKeySequence in the displayText function

### DIFF
--- a/Applications/Spire/Source/Ui/CustomQtVariants.cpp
+++ b/Applications/Spire/Source/Ui/CustomQtVariants.cpp
@@ -314,8 +314,6 @@ QString CustomVariantItemDelegate::displayText(const QVariant& value,
     return Spire::displayText(value.value<Side>());
   } else if(value.canConvert<TimeInForce>()) {
     return Spire::displayText(value.value<TimeInForce>().GetType());
-  } else if(value.canConvert<QKeySequence>()) {
-    return value.value<QKeySequence>().toString();
   } else if(value.canConvert<std::any>()) {
     auto translated_value = to_qvariant(value.value<std::any>());
     return displayText(translated_value, locale);


### PR DESCRIPTION
Removed the conversion to QKeySequence in displayText function which can be done by Qt by defalut. The int and QString can be converted to QKeySequence, so they will be displayed as sepcial characters in displayText function.