### PR TITLE
The right padding of the TextBox in the ListItem of the DropDownBox

### DIFF
--- a/Applications/Spire/Source/Ui/DropDownBox.cpp
+++ b/Applications/Spire/Source/Ui/DropDownBox.cpp
@@ -26,11 +26,12 @@ namespace {
       set(BackgroundColor(QColor(Qt::transparent)));
     style.get(Disabled() >> is_a<Icon>()).set(Fill(QColor(0xC8C8C8)));
     style.get(ReadOnly() >> is_a<Icon>()).set(Visibility::NONE);
-    style.get(Any() >> is_a<TextBox>()).set(PaddingRight(scale_width(14)));
+    style.get(Any() >> (is_a<TextBox>() && !(+Any() << is_a<ListItem>()))).
+      set(PaddingRight(scale_width(14)));
     style.get(PopUp() >> is_a<TextBox>() ||
       (+Any() >> is_a<Button>() && (Hover() || FocusIn())) >> is_a<TextBox>()).
       set(border_color(QColor(0x4B23A0)));
-    style.get(ReadOnly() >> is_a<TextBox>()).
+    style.get(ReadOnly() >> (is_a<TextBox>() && !(+Any() << is_a<ListItem>()))).
       set(horizontal_padding(0)).
       set(border_color(QColor(Qt::transparent))).
       set(BackgroundColor(QColor(Qt::transparent)));


### PR DESCRIPTION
The right padding styling is supposed to be applied to the TextBox inside the Button, but it also is used to the TextBox of the ListItem. The purpose of the commit is to exclude the styling from the TextBox of the ListItem.