### PR TITLE
sizeHint of the ScrollBox

### DIFF
--- a/Applications/Spire/Source/Ui/ScrollBox.cpp
+++ b/Applications/Spire/Source/Ui/ScrollBox.cpp
@@ -171,14 +171,14 @@ QSize ScrollBox::sizeHint() const {
   if(m_vertical_display_policy == DisplayPolicy::ALWAYS ||
       m_vertical_display_policy == DisplayPolicy::ON_ENGAGE ||
       m_vertical_display_policy == DisplayPolicy::ON_OVERFLOW &&
-      m_scrollable_layer->get_vertical_scroll_bar().isVisible()) {
+      !m_scrollable_layer->get_vertical_scroll_bar().isHidden()) {
     size.rwidth() +=
       m_scrollable_layer->get_vertical_scroll_bar().sizeHint().width();
   }
   if(m_horizontal_display_policy == DisplayPolicy::ALWAYS ||
       m_horizontal_display_policy == DisplayPolicy::ON_ENGAGE ||
       m_horizontal_display_policy == DisplayPolicy::ON_OVERFLOW &&
-      m_scrollable_layer->get_horizontal_scroll_bar().isVisible()) {
+      !m_scrollable_layer->get_horizontal_scroll_bar().isHidden()) {
     size.rheight() +=
       m_scrollable_layer->get_horizontal_scroll_bar().sizeHint().height();
   }


### PR DESCRIPTION
Ensured the sizeHint of the ScrollBox returns the correct size when it is not visible but the scroll bars are not hidden. IsVisible and IsHidden are slightly different:
> isHidden() implies !isVisible(), but a widget can be not visible and not hidden at the same time. This is the case for widgets that are children of widgets that are not visible.