### PR TITLE
The Box gets QEvent::LayoutRequest event before it is resized

### DIFF
--- a/Applications/Spire/Source/Ui/Box.cpp
+++ b/Applications/Spire/Source/Ui/Box.cpp
@@ -41,6 +41,8 @@ Box::Box(QWidget* body, QWidget* parent)
       m_body(body),
       m_styles([=] { commit_style(); }) {
   setObjectName(QString("0x%1").arg(reinterpret_cast<std::intptr_t>(this)));
+  auto box_layout = new QHBoxLayout(this);
+  box_layout->setContentsMargins({});
   if(m_body) {
     m_container = new QWidget(this);
     auto layout = new QHBoxLayout(m_container);


### PR DESCRIPTION
Added an empty layout to the Box, which can make the Box receive QEvent::LayoutRequest event and update its size hint before its parent starts to resize. It can resolve the issue where the Box can't update the size hint in time after the body component has updated its layout.