### PR TITLE
Potential fix for ListView's navigation box update issue when the cur…

### DIFF
--- a/Applications/Spire/Source/Ui/ListView.cpp
+++ b/Applications/Spire/Source/Ui/ListView.cpp
@@ -337,7 +337,9 @@ void ListView::cross(int direction) {
   }
   m_navigation_box = navigation_box;
   set_current(candidate);
-  m_navigation_box = navigation_box;
+  if(candidate == m_current_model->get_current()) {
+    m_navigation_box = navigation_box;
+  }
 }
 
 void ListView::set_current(optional<int> current) {


### PR DESCRIPTION
The Scratch demo in the folder will reset the current to 15 if 12 becomes the current. This is to test that the cross move works properly after the current is reset in response to an initial change of current. The UiViewer demo is to demonstrate that there are no regressions with the cross move.