### PR TITLE
Reposition the Overlay Panel.

### DIFF
--- a/Applications/Spire/Include/Spire/Ui/OverlayPanel.hpp
+++ b/Applications/Spire/Include/Spire/Ui/OverlayPanel.hpp
@@ -2,7 +2,6 @@
 #define SPIRE_OVERLAY_PANEL_HPP
 #include "Spire/Ui/FocusObserver.hpp"
 #include "Spire/Ui/Ui.hpp"
-#include "Spire/Ui/WindowObserver.hpp"
 
 namespace Spire {
 
@@ -77,6 +76,7 @@ namespace Spire {
       void resizeEvent(QResizeEvent* event) override;
 
     private:
+      class ParentMoveObserver;
       QWidget* m_body;
       bool m_is_closed_on_focus_out;
       bool m_is_draggable;
@@ -84,8 +84,7 @@ namespace Spire {
       Positioning m_positioning;
       QPoint m_mouse_pressed_position;
       FocusObserver m_focus_observer;
-      WindowObserver m_window_observer;
-      QWidget* m_window;
+      std::unique_ptr<ParentMoveObserver> m_parent_move_observer;
       boost::signals2::scoped_connection m_focus_connection;
       FocusObserver m_parent_focus_observer;
       boost::signals2::scoped_connection m_parent_focus_connection;
@@ -93,7 +92,7 @@ namespace Spire {
       void position();
       void on_focus(FocusObserver::State state);
       void on_parent_focus(FocusObserver::State state);
-      void on_window(QWidget* window);
+      void on_parent_move();
       void update_mask();
   };
 }

--- a/Applications/Spire/Include/Spire/Ui/OverlayPanel.hpp
+++ b/Applications/Spire/Include/Spire/Ui/OverlayPanel.hpp
@@ -1,6 +1,7 @@
 #ifndef SPIRE_OVERLAY_PANEL_HPP
 #define SPIRE_OVERLAY_PANEL_HPP
 #include "Spire/Ui/FocusObserver.hpp"
+#include "Spire/Ui/GlobalPositionObserver.hpp"
 #include "Spire/Ui/Ui.hpp"
 
 namespace Spire {
@@ -76,7 +77,6 @@ namespace Spire {
       void resizeEvent(QResizeEvent* event) override;
 
     private:
-      class ParentMoveObserver;
       QWidget* m_body;
       bool m_is_closed_on_focus_out;
       bool m_is_draggable;
@@ -84,15 +84,16 @@ namespace Spire {
       Positioning m_positioning;
       QPoint m_mouse_pressed_position;
       FocusObserver m_focus_observer;
-      std::unique_ptr<ParentMoveObserver> m_parent_move_observer;
       boost::signals2::scoped_connection m_focus_connection;
       FocusObserver m_parent_focus_observer;
       boost::signals2::scoped_connection m_parent_focus_connection;
+      GlobalPositionObserver m_parent_position_observer;
+      boost::signals2::scoped_connection m_parent_position_connection;
 
       void position();
       void on_focus(FocusObserver::State state);
       void on_parent_focus(FocusObserver::State state);
-      void on_parent_move();
+      void on_parent_move(QPoint);
       void update_mask();
   };
 }

--- a/Applications/Spire/Source/UiViewer/StandardUiProfiles.cpp
+++ b/Applications/Spire/Source/UiViewer/StandardUiProfiles.cpp
@@ -2263,6 +2263,7 @@ UiProfile Spire::make_order_type_filter_panel_profile() {
 
 UiProfile Spire::make_overlay_panel_profile() {
   auto properties = std::vector<std::shared_ptr<UiProperty>>();
+  populate_widget_properties(properties);
   properties.push_back(make_standard_property("close-on-focus-out", false));
   properties.push_back(make_standard_property("draggable", true));
   auto positioning_property = define_enum<OverlayPanel::Positioning>(
@@ -2277,6 +2278,7 @@ UiProfile Spire::make_overlay_panel_profile() {
     auto& positioning =
       get<OverlayPanel::Positioning>("positioning", profile.get_properties());
     auto button = make_label_button("Click me");
+    apply_widget_properties(button, profile.get_properties());
     auto panel = QPointer<OverlayPanel>();
     button->connect_clicked_signal(
       [=, &profile, &close_on_focus_out, &draggable, &positioning]


### PR DESCRIPTION
Fixed the issue where the OverlayPanel doesn’t move with the height change of the parent widget.

When the position of the OverlayPanel’s ancestor (not direct parent) changes, whether it is caused by moving window or layout changing, the OverlayPanel might not get the Move event from its direct parent, because the position of direct parent might have not changed relative to the ancestor.

The added ParentMoveObserver is used to listen to the Move event of all ancestors of the OverlayPanel, including the top-level window. When the position of any one of the ancestors changes, the OverlayPanel can know the change and reposition to follow its parent. 

