### PR TITLE
The MinimumSizeHint of the QLineEdit 

### DIFF
--- a/Applications/Spire/Source/Ui/TextBox.cpp
+++ b/Applications/Spire/Source/Ui/TextBox.cpp
@@ -248,6 +248,10 @@ class TextBox::LineEdit : public QLineEdit {
       QLineEdit::resizeEvent(event);
     }
 
+    QSize minimumSizeHint() const override {
+      return {0, 0};
+    }
+
   private:
     mutable RejectSignal m_reject_signal;
     TextBox* m_text_box;

--- a/Applications/Spire/Source/UiViewer/StandardUiProfiles.cpp
+++ b/Applications/Spire/Source/UiViewer/StandardUiProfiles.cpp
@@ -3008,6 +3008,7 @@ UiProfile Spire::make_text_box_profile() {
   properties.push_back(make_standard_property<QString>("placeholder"));
   properties.push_back(make_standard_property<QString>("rejected", "deny"));
   properties.push_back(make_standard_property("horizontal_padding", 8));
+  properties.push_back(make_standard_property("border_size", 1));
   auto profile = UiProfile("TextBox", properties, [] (auto& profile) {
     auto model = std::make_shared<RejectedTextModel>();
     auto text_box = new TextBox(model);
@@ -3031,6 +3032,12 @@ UiProfile Spire::make_text_box_profile() {
     padding.connect_changed_signal([=] (const auto& value) {
       update_style(*text_box, [&] (auto& style) {
         style.get(Any()).set(horizontal_padding(scale_width(value)));
+      });
+    });
+    auto& border = get<int>("border_size", profile.get_properties());
+    border.connect_changed_signal([=] (const auto& value) {
+      update_style(*text_box, [&] (auto& style) {
+        style.get(Any()).set(border_size(scale_width(value)));
       });
     });
     text_box->get_current()->connect_update_signal(


### PR DESCRIPTION
The minimum height of the QLineEdit might prevent the TextBox from shrinking when the height of the TextBox is less than it.