### PR TITLE
The overflow of the TagBox in a wrapper

### DIFF
--- a/Applications/Spire/Include/Spire/Ui/RegionBox.hpp
+++ b/Applications/Spire/Include/Spire/Ui/RegionBox.hpp
@@ -59,10 +59,6 @@ namespace Spire {
       boost::signals2::connection connect_submit_signal(
         const SubmitSignal::slot_type& slot) const;
 
-    protected:
-      bool event(QEvent* event) override;
-      void resizeEvent(QResizeEvent* event) override;
-
     private:
       struct RegionQueryModel;
       mutable SubmitSignal m_submit_signal;
@@ -72,7 +68,6 @@ namespace Spire {
       boost::signals2::scoped_connection m_current_connection;
       boost::signals2::scoped_connection m_tag_operation_connection;
 
-      void update_min_max_size();
       void on_current(const Nexus::Region& region);
       void on_submit(const std::shared_ptr<AnyListModel>& submission);
       void on_tags_operation(const AnyListModel::Operation& operation);

--- a/Applications/Spire/Include/Spire/Ui/TagComboBox.hpp
+++ b/Applications/Spire/Include/Spire/Ui/TagComboBox.hpp
@@ -73,9 +73,7 @@ namespace Spire {
 
     protected:
       bool eventFilter(QObject* watched, QEvent* event) override;
-      bool event(QEvent* event) override;
       void showEvent(QShowEvent* event) override;
-      void resizeEvent(QResizeEvent* event) override;
 
     private:
       mutable SubmitSignal m_submit_signal;
@@ -89,7 +87,6 @@ namespace Spire {
       boost::signals2::scoped_connection m_list_connection;
 
       void submit();
-      void update_min_max_size();
       void on_combo_box_submit(const std::any& submission);
       void on_focus(FocusObserver::State state);
       void on_operation(const AnyListModel::Operation& operation);

--- a/Applications/Spire/Source/Ui/RegionBox.cpp
+++ b/Applications/Spire/Source/Ui/RegionBox.cpp
@@ -1,7 +1,6 @@
 #include "Spire/Ui/RegionBox.hpp"
 #include <boost/iterator/counting_iterator.hpp>
 #include <boost/signals2/shared_connection_block.hpp>
-#include <QMoveEvent>
 #include "Spire/Spire/ArrayListModel.hpp"
 #include "Spire/Spire/LocalValueModel.hpp"
 #include "Spire/Ui/CustomQtVariants.hpp"

--- a/Applications/Spire/Source/Ui/RegionBox.cpp
+++ b/Applications/Spire/Source/Ui/RegionBox.cpp
@@ -174,27 +174,6 @@ connection RegionBox::connect_submit_signal(
   return m_submit_signal.connect(slot);
 }
 
-bool RegionBox::event(QEvent* event) {
-  if(event->type() == QEvent::LayoutRequest) {
-    update_min_max_size();
-  }
-  return QWidget::event(event);
-}
-
-void RegionBox::resizeEvent(QResizeEvent* event) {
-  update_min_max_size();
-  QWidget::resizeEvent(event);
-}
-
-void RegionBox::update_min_max_size() {
-  if(m_tag_combo_box->minimumSize() != minimumSize()) {
-    m_tag_combo_box->setMinimumSize(minimumSize());
-  }
-  if(m_tag_combo_box->maximumSize() != maximumSize()) {
-    m_tag_combo_box->setMaximumSize(maximumSize());
-  }
-}
-
 void RegionBox::on_current(const Region& region) {
   auto blocker = shared_connection_block(m_tag_operation_connection);
   auto& current = m_tag_combo_box->get_current();

--- a/Applications/Spire/Source/Ui/TagComboBox.cpp
+++ b/Applications/Spire/Source/Ui/TagComboBox.cpp
@@ -226,13 +226,6 @@ bool TagComboBox::eventFilter(QObject* watched, QEvent* event) {
   return QWidget::eventFilter(watched, event);
 }
 
-bool TagComboBox::event(QEvent* event) {
-  if(event->type() == QEvent::LayoutRequest) {
-    update_min_max_size();
-  }
-  return QWidget::event(event);
-}
-
 void TagComboBox::showEvent(QShowEvent* event) {
   if(!m_input_box) {
     m_input_box = find_focus_proxy(*m_tag_box);
@@ -241,24 +234,10 @@ void TagComboBox::showEvent(QShowEvent* event) {
   QWidget::showEvent(event);
 }
 
-void TagComboBox::resizeEvent(QResizeEvent* event) {
-  update_min_max_size();
-  QWidget::resizeEvent(event);
-}
-
 void TagComboBox::submit() {
   copy_list_model(get_current(), m_submission);
   m_is_modified = false;
   m_submit_signal(m_submission);
-}
-
-void TagComboBox::update_min_max_size() {
-  if(m_tag_box->minimumSize() != minimumSize()) {
-    m_tag_box->setMinimumSize(minimumSize());
-  }
-  if(m_tag_box->maximumSize() != maximumSize()) {
-    m_tag_box->setMaximumSize(maximumSize());
-  }
 }
 
 void TagComboBox::on_combo_box_submit(const std::any& submission) {

--- a/Applications/Spire/Source/UiViewer/StandardUiProfiles.cpp
+++ b/Applications/Spire/Source/UiViewer/StandardUiProfiles.cpp
@@ -1613,7 +1613,7 @@ UiProfile Spire::make_editable_box_profile() {
   auto properties = std::vector<std::shared_ptr<UiProperty>>();
   populate_widget_properties(properties);
   auto test_widget_property = define_enum<int>(
-    {{"TextBox", 0}, {"DropDownBox", 1}, {"DecimalBox", 2}});
+    {{"TextBox", 0}, {"DropDownBox", 1}, {"DecimalBox", 2}, {"RegionBox", 3}});
   properties.push_back(
     make_standard_enum_property("input_box", test_widget_property));
   auto profile = UiProfile("EditableBox", properties, [] (auto& profile) {
@@ -1628,9 +1628,14 @@ UiProfile Spire::make_editable_box_profile() {
           list_model->push(QString("item%1").arg(i));
         }
         return new AnyInputBox(*(new DropDownBox(list_model)));
+      } else if(value == 2) {
+        return new AnyInputBox((*new DecimalBox(
+          std::make_shared<LocalOptionalDecimalModel>(Decimal(1)))));
       }
-      return new AnyInputBox((*new DecimalBox(
-        std::make_shared<LocalOptionalDecimalModel>(Decimal(1)))));
+      auto query_model = populate_region_box_model();
+      auto current = std::make_shared<LocalValueModel<Region>>();
+      current->set(std::any_cast<Region>(query_model->parse("TSX")));
+      return new AnyInputBox((*new RegionBox(query_model, current)));
     }();
     auto editable_box = new EditableBox(*input_box);
     editable_box->setMinimumWidth(scale_width(112));


### PR DESCRIPTION
Instead of setting fixed size from parent to child, for example, the `TagComboBox` or `RegionBox` sets fixed size to the `TagBox`, the new approach is to get fixed size from the `TagBox’s` wrapper (I think the fixed size of the root wrapper would be the size of the `TagBox`). The `TagBox’s` wrapper is the component that wraps one and only one `TagBox` and provides additional functionality to the `TagBox`. The `TagBox` traverses up its parent hierarchy and looks for the root wrapper. 