### PR TITLE
RegionBox crash

### DIFF
--- a/Applications/Spire/Include/Spire/Ui/TagBox.hpp
+++ b/Applications/Spire/Include/Spire/Ui/TagBox.hpp
@@ -96,6 +96,7 @@ namespace Spire {
       void on_focus(FocusObserver::State state);
       void on_operation(const AnyListModel::Operation& operation);
       void on_text_box_current(const QString& current);
+      void on_list_view_current(const boost::optional<int>& current);
       void on_list_view_submit(const std::any& submission);
       void on_style();
       void on_list_view_style();

--- a/Applications/Spire/Source/Ui/TagBox.cpp
+++ b/Applications/Spire/Source/Ui/TagBox.cpp
@@ -196,6 +196,8 @@ TagBox::TagBox(std::shared_ptr<AnyListModel> list,
     std::bind_front(&TagBox::on_operation, this));
   m_list_view->connect_submit_signal(
     std::bind_front(&TagBox::on_list_view_submit, this));
+  m_list_view->get_current()->connect_update_signal(
+    std::bind_front(&TagBox::on_list_view_current, this));
   m_list_view->setFocusPolicy(Qt::NoFocus);
   m_list_view->installEventFilter(this);
   m_scrollable_list_box = new ScrollableListBox(*m_list_view);
@@ -555,6 +557,12 @@ void TagBox::on_operation(const AnyListModel::Operation& operation) {
 void TagBox::on_text_box_current(const QString& current) {
   m_list_view->adjustSize();
   scroll_to_text_box();
+}
+
+void TagBox::on_list_view_current(const optional<int>& current) {
+  if(current) {
+    m_list_view->get_current()->set(none);
+  }
 }
 
 void TagBox::on_list_view_submit(const std::any& submission) {


### PR DESCRIPTION
Since the ListView within the TagBox should not have a current item (There is no navigation between list of tags), the TagBox forbids the ListView to get a valid current.