### PR TITLE
Popup box fix

### DIFF
--- a/Applications/Spire/Include/Spire/Ui/PopupBox.hpp
+++ b/Applications/Spire/Include/Spire/Ui/PopupBox.hpp
@@ -51,6 +51,7 @@ namespace Spire {
       int m_above_space;
       int m_below_space;
       int m_right_space;
+      boost::signals2::scoped_connection m_focus_connection;
 
       bool has_popped_up() const;
       void align();

--- a/Applications/Spire/Include/Spire/Ui/PopupBox.hpp
+++ b/Applications/Spire/Include/Spire/Ui/PopupBox.hpp
@@ -57,6 +57,7 @@ namespace Spire {
       void align();
       void adjust_size();
       void set_position(const QPoint& pos);
+      void update_window();
       void update_space();
       void on_body_focus(FocusObserver::State state);
       void on_focus(FocusObserver::State state);

--- a/Applications/Spire/Source/Ui/PopupBox.cpp
+++ b/Applications/Spire/Source/Ui/PopupBox.cpp
@@ -1,6 +1,6 @@
 #include "Spire/Ui/PopupBox.hpp"
 #include <boost/signals2/shared_connection_block.hpp>
-#include <QApplication>
+#include <QEvent>
 #include "Spire/Styles/Stylist.hpp"
 #include "Spire/Ui/Layouts.hpp"
 
@@ -155,8 +155,7 @@ void PopupBox::update_space() {
 }
 
 void PopupBox::on_body_focus(FocusObserver::State state) {
-  if(state == FocusObserver::State::NONE && has_popped_up() &&
-      QApplication::focusWidget()) {
+  if(state == FocusObserver::State::NONE && has_popped_up()) {
     m_body->setFixedHeight(m_min_height);
     m_body->setMinimumWidth(0);
     m_body->setMaximumWidth(QWIDGETSIZE_MAX);


### PR DESCRIPTION
It fixed the following issues related to the Key Bindings:
1. Tabbing to the RegionBox for the first time results in the row being vertically resized and the TagBox appearing in a separate window. (The 19th issue in the bug list of OrderTasksPage https://app.asana.com/0/0/1202711143074276/1203534960581752/f)
2. If the user switches windows while the region box is editing and popped-out, then switches back to the KeyBindings window, the layout of the tags will overlap the cells below rather than being placed horizontally and overflowing the cell. (The 10th issue in the bug list of OrderTasksPage.)
