### PR TITLE
TableView sort order.

### DIFF
--- a/Applications/Spire/Source/Ui/TableView.cpp
+++ b/Applications/Spire/Source/Ui/TableView.cpp
@@ -126,8 +126,10 @@ void TableView::on_order_update(int index, TableHeaderItem::Order order) {
       m_header->set(i, header_item);
     } else {
       auto item = m_header->get(i);
-      item.m_order = TableHeaderItem::Order::NONE;
-      m_header->set(i, item);
+      if(item.m_order != TableHeaderItem::Order::UNORDERED) {
+        item.m_order = TableHeaderItem::Order::NONE;
+        m_header->set(i, item);
+      }
     }
   }
   m_sort_signal(index, order);


### PR DESCRIPTION
If the header item is unordered, it should not be involved in the order cycle.