### PR TITLE
TableCurrentController and TableSelectionController calucate wrong row index

### DIFF
--- a/Applications/Spire/Source/Ui/TableCurrentController.cpp
+++ b/Applications/Spire/Source/Ui/TableCurrentController.cpp
@@ -61,9 +61,16 @@ void TableCurrentController::move_row(int source, int destination) {
     return 1;
   }();
   auto adjust = [&] (auto& value) {
-    if(value && (value->m_row >= source || value->m_row <= destination)) {
-      value->m_row += direction;
-      return true;
+    if(value) {
+      if(value->m_row == source) {
+        value->m_row = destination;
+        return true;
+      } else if(direction == 1 && value->m_row >= destination &&
+          value->m_row < source || direction == -1 && value->m_row > source &&
+          value->m_row <= destination) {
+        value->m_row += direction;
+        return true;
+      }
     }
     return false;
   };

--- a/Applications/Spire/Source/Ui/TableSelectionController.cpp
+++ b/Applications/Spire/Source/Ui/TableSelectionController.cpp
@@ -200,14 +200,23 @@ void TableSelectionController::move_row(int source, int destination) {
     auto& rows = m_selection->get_row_selection();
     for(auto i = 0; i != rows->get_size(); ++i) {
       auto selection = rows->get(i);
-      if(selection >= source || selection <= destination) {
+      if(selection == source) {
+        rows->set(i, destination);
+      } else if(direction == 1 && selection >= destination &&
+          selection < source || direction == -1 && selection > source &&
+          selection <= destination) {
         rows->set(i, selection + direction);
       }
     }
     auto& items = m_selection->get_item_selection();
     for(auto i = 0; i != items->get_size(); ++i) {
       auto selection = items->get(i);
-      if(selection.m_row >= source || selection.m_row <= destination) {
+      if(selection.m_row == source) {
+        selection.m_row = destination;
+        items->set(i, selection);
+      } else if(direction == 1 && selection.m_row >= destination &&
+          selection.m_row < source || direction == -1 &&
+          selection.m_row > source && selection.m_row <= destination) {
         selection.m_row += direction;
         items->set(i, selection);
       }


### PR DESCRIPTION
It fixed the issue of [TableView crashes when it is sorting and the current row is the last row.](https://app.asana.com/0/1169210941620249/1203563868277689/f)