### PR TITLE
The hover widget of the TableBody

### DIFF
--- a/Applications/Spire/Source/Ui/TableBody.cpp
+++ b/Applications/Spire/Source/Ui/TableBody.cpp
@@ -3,6 +3,7 @@
 #include <QEnterEvent>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QPointer>
 #include "Spire/Spire/ArrayListModel.hpp"
 #include "Spire/Spire/Dimensions.hpp"
 #include "Spire/Spire/LocalValueModel.hpp"
@@ -40,11 +41,10 @@ struct TableBody::Cover : QWidget {
 };
 
 struct TableBody::ColumnCover : Cover {
-  QWidget* m_hovered;
+  QPointer<QWidget> m_hovered;
 
   ColumnCover(QWidget* parent)
-      : Cover(parent),
-        m_hovered(nullptr) {
+      : Cover(parent) {
     setMouseTracking(true);
   }
 
@@ -68,7 +68,7 @@ struct TableBody::ColumnCover : Cover {
         QCoreApplication::sendEvent(m_hovered, &leave_event);
       }
       if(hovered_widget == parentWidget()) {
-        m_hovered = nullptr;
+        m_hovered.clear();
       } else {
         m_hovered = hovered_widget;
         if(m_hovered) {


### PR DESCRIPTION
Fixed the issue of [TableView crashes when hovering on the KeyInputBox which is placed in a cell.](https://app.asana.com/0/0/1202884354318062/f)