### PR TITLE
Raise the column covers

### DIFF
--- a/Applications/Spire/Source/Ui/TableBody.cpp
+++ b/Applications/Spire/Source/Ui/TableBody.cpp
@@ -206,6 +206,7 @@ bool TableBody::event(QEvent* event) {
       }();
       cover->setFixedSize(width, height());
       left += width;
+      cover->raise();
     }
     return result;
   } else {


### PR DESCRIPTION
Since the last added widget is the topmost, the added rows of the `TableView` are in front of any overlapping sibling widgets, including the column covers. As a result, the column covers no longer receive and forward mouse events.

This fix is to keep the column covers always on top of the parent widget's stack.