### PR TITLE
Two underlying issues in TableBody::on_style

### DIFF
--- a/Applications/Spire/Source/Ui/TableBody.cpp
+++ b/Applications/Spire/Source/Ui/TableBody.cpp
@@ -546,15 +546,16 @@ void TableBody::on_style() {
   }
   auto& row_layout = *layout();
   for(auto row = 0; row != row_layout.count(); ++row) {
-    row_layout.itemAt(row)->layout()->setSpacing(m_styles.m_horizontal_spacing);
+    row_layout.itemAt(row)->widget()->layout()->setSpacing(
+      m_styles.m_horizontal_spacing);
   }
   row_layout.setSpacing(m_styles.m_vertical_spacing);
   row_layout.setContentsMargins({
     m_styles.m_horizontal_spacing, m_styles.m_vertical_spacing,
     m_styles.m_horizontal_spacing, m_styles.m_vertical_spacing});
   for(auto row = 0; row != row_layout.count(); ++row) {
-    auto& column_layout = *row_layout.itemAt(row)->layout();
-    for(auto column = 0; column != column_layout.count(); ++column) {
+    auto& column_layout = *row_layout.itemAt(row)->widget()->layout();
+    for(auto column = 0; column != m_widths->get_size(); ++column) {
       auto& item = *column_layout.itemAt(column)->widget();
       item.setFixedWidth(m_widths->get(column) - m_styles.m_horizontal_spacing);
     }


### PR DESCRIPTION
There are two potential issues in `TableBody::on_style`. Since the `TableBody`’s style isn’t updated after `TableBody` is created, the issue has not yet caused the crash.

1. `Layout::itemAt(int index)` returns a `QLayoutItem`. The `QLayoutItem::layout()` returns `nullptr` when it is not a `QLayout`. In our case, the layout of the `QLayoutItem::widget()` should be returned rather than the layout of `QLayoutItem` itself.
https://doc.qt.io/qt-5/qlayoutitem.html#layout

2. The `TableBody::m_widths` only stores the width of the first n - 1 columns, so the size of `m_widths` is the number of columns minus 1. If the size of `column_layout` is used in the loop, accessing `m_widths` will be out of bounds.
