### PR TITLE
The scrollbar scrolling to the top when a new row is added

### DIFF
--- a/Applications/Spire/Include/Spire/KeyBindings/OrderTasksRow.hpp
+++ b/Applications/Spire/Include/Spire/KeyBindings/OrderTasksRow.hpp
@@ -77,6 +77,9 @@ namespace Styles {
       /** Returns the row index. */
       int get_row_index() const;
 
+      /** Returns the row widget. */
+      QWidget* get_row() const;
+
       /** Returns <code>true</code> iff this row is draggable. */
       bool is_draggable() const;
 

--- a/Applications/Spire/Source/KeyBindings/OrderTasksPage.cpp
+++ b/Applications/Spire/Source/KeyBindings/OrderTasksPage.cpp
@@ -780,6 +780,7 @@ void OrderTasksPage::on_view_table_operation(
     const TableModel::Operation& operation) {
   visit(operation,
     [&] (const TableModel::AddOperation& operation) {
+      m_rows[operation.m_index]->get_row()->show();
       if(m_added_row.m_source_index != -1) {
         if(auto current = m_table_body->get_current()->get()) {
           m_table_body->get_current()->set(

--- a/Applications/Spire/Source/KeyBindings/OrderTasksRow.cpp
+++ b/Applications/Spire/Source/KeyBindings/OrderTasksRow.cpp
@@ -232,6 +232,10 @@ int OrderTasksRow::get_row_index() const {
   return m_row_index;
 }
 
+QWidget* OrderTasksRow::get_row() const {
+  return m_row;
+}
+
 bool OrderTasksRow::is_draggable() const {
   return m_is_draggable;
 }


### PR DESCRIPTION
It is related to the task [The scrollbar scrolling to the top when a new row is added](https://app.asana.com/0/0/1203756802316159/f).

Showing the newly added row can recalculate the correct row geometry which will be used to calculate the scrollbar position, before entering the Qt event loop.