### PR TITLE
TextBox focus policy

### DIFF
--- a/Applications/Spire/Source/Ui/TextBox.cpp
+++ b/Applications/Spire/Source/Ui/TextBox.cpp
@@ -138,7 +138,7 @@ class TextBox::LineEdit : public QLineEdit {
       m_highlight_connection = m_highlight->connect_update_signal(
         std::bind_front(&LineEdit::on_highlight, this));
       m_text_box->setCursor(cursor());
-      m_text_box->setFocusPolicy(focusPolicy());
+      setFocusPolicy(m_text_box->focusPolicy());
       QWidget::setTabOrder(m_text_box, this);
       m_text_box->setFocusProxy(this);
       enclose(*m_text_box, *this);
@@ -396,6 +396,7 @@ TextBox::TextBox(std::shared_ptr<TextModel> current, QWidget* parent)
       m_is_read_only(false),
       m_highlight(std::make_shared<LocalValueModel<Highlight>>()),
       m_line_edit(nullptr) {
+  setFocusPolicy(Qt::StrongFocus);
   add_pseudo_element(*this, Placeholder());
   m_style_connection = connect_style_signal(*this, [=] { on_style(); });
   set_style(*this, DEFAULT_STYLE());


### PR DESCRIPTION
Since the `LineEdit` is the focus proxy of the `TextBox`, the focus policy should be set from the `TextBox` to the `LineEdit` instead of from the `LineEdit` to `TextBox`. That means the `TextBox` should decide the focus policy of its focus proxy (the `LineEdit`), not the other way around.

This update is relative to the task of [Unclear focus order and crash on interaction](https://app.asana.com/0/0/1204204934146705/f).