### PR TITLE
Added the focus proxy to the SearchBox.

### DIFF
--- a/Applications/Spire/Source/Ui/SearchBox.cpp
+++ b/Applications/Spire/Source/Ui/SearchBox.cpp
@@ -67,6 +67,7 @@ SearchBox::SearchBox(std::shared_ptr<TextModel> model, QWidget* parent)
   container_layout->addWidget(m_delete_button);
   auto box = new Box(container);
   enclose(*this, *box);
+  setFocusProxy(box);
   proxy_style(*this, *box);
   set_style(*this, DEFAULT_STYLE());
   m_current_connection = m_text_box->get_current()->connect_update_signal(


### PR DESCRIPTION
Set the `SearchBox's` focus proxy to the `box` whose focus proxy is the `TextBox`, so the final focus proxy of the `SearchBox` is the `TextBox`.