### PR TITLE
The TableView ignores the keyPress event of "a"

### DIFF
--- a/Applications/Spire/Source/Ui/TableBody.cpp
+++ b/Applications/Spire/Source/Ui/TableBody.cpp
@@ -283,6 +283,8 @@ void TableBody::keyPressEvent(QKeyEvent* event) {
     case Qt::Key_A:
       if(event->modifiers() & Qt::Modifier::CTRL && !event->isAutoRepeat()) {
         m_selection_controller.select_all();
+      } else {
+        event->ignore();
       }
       break;
     case Qt::Key_Control:


### PR DESCRIPTION
This pull request refers to the task of [The TableView prevents “a” from propagating to the parent widget.]( https://app.asana.com/0/0/1204523662177982/f)