### PR TITLE
The horizontal scroll bar scrolls a line in a wrong direction.

### DIFF
--- a/Applications/Spire/Source/Ui/ScrollableLayer.cpp
+++ b/Applications/Spire/Source/Ui/ScrollableLayer.cpp
@@ -48,7 +48,7 @@ void ScrollableLayer::keyPressEvent(QKeyEvent* event) {
   } else if(event->key() == Qt::Key_Right) {
     scroll_line_down(*m_horizontal_scroll_bar);
   } else if(event->key() == Qt::Key_Left) {
-    scroll_line_down(*m_horizontal_scroll_bar);
+    scroll_line_up(*m_horizontal_scroll_bar);
   } else if(event->key() == Qt::Key_PageUp) {
     scroll_page_up(*m_vertical_scroll_bar);
   } else if(event->key() == Qt::Key_PageDown) {


### PR DESCRIPTION
The left array key should navigate to left horizontally. However, `scroll_line_down` increases the position of the scrollbar, resulting in the horizontal scrollbar scrolling to right. Hence, `scroll_line_up` should be used for `Qt::Key_Left`.