### PR TITLE
Qt warnings

### DIFF
--- a/Applications/Spire/Source/Ui/TableBody.cpp
+++ b/Applications/Spire/Source/Ui/TableBody.cpp
@@ -235,6 +235,7 @@ bool TableBody::event(QEvent* event) {
         }
         return this->width() - left;
       }();
+      width = std::max(0, width);
       cover->setFixedSize(width, height());
       left += width;
       cover->raise();


### PR DESCRIPTION
Qt outputs a warning of “QWidget::setMinimumSize: (/QWidget) Negative sizes (-13, 552) are not possible”, when showing/hiding the table columns. The reason is that the column minimum width is set to a negative value when the width of the window is less than the total width of all columns.

Although Qt can correct the minimum width to be a non-negative value, I think it should be handled before Qt deals with it.