### PR TITLE
Installs the event filter to the QLineEdit when it is addecd to the TextBox.

### DIFF
--- a/Applications/Spire/Include/Spire/Ui/HexColorBox.hpp
+++ b/Applications/Spire/Include/Spire/Ui/HexColorBox.hpp
@@ -58,7 +58,6 @@ namespace Spire {
 
     protected:
       bool eventFilter(QObject* watched, QEvent* event) override;
-      void showEvent(QShowEvent* event) override;
 
     private:
       struct ColorToTextModel;


### PR DESCRIPTION
This update is not intended to fix a bug, but to improve the performance of the HexColorBox. In the previous version, the event filter was installed into the TextBox’s QLineEdit in the show event, which could cause the installation to be executed multiple times when the HexColorBox was shown and hidden multiple times. The event filter is now only installed to the QLineEdit when the QLineEdit is added to the TextBox, which only happens once for an already created HexColorBox.

