### PR TITLE
TextBox missing submit signal

### DIFF
--- a/Applications/Spire/Source/Ui/TextBox.cpp
+++ b/Applications/Spire/Source/Ui/TextBox.cpp
@@ -323,6 +323,7 @@ class TextBox::LineEdit : public QLineEdit {
         if(m_current->get_state() == QValidator::Acceptable) {
           m_submission = m_current->get();
           m_has_update = false;
+          m_submit_signal(m_submission);
         } else {
           m_reject_signal(m_current->get());
           m_current->set(m_submission);


### PR DESCRIPTION
The updated TextBox is missing the submit signal when the Enter key is pressed or the TextBox focuses out. This PR is trying to fixed it.