### PR TITLE
FontFamilyBox Update

### DIFF
--- a/Applications/Spire/Source/Ui/FontFamilyBox.cpp
+++ b/Applications/Spire/Source/Ui/FontFamilyBox.cpp
@@ -43,10 +43,11 @@ FontFamilyBox* Spire::make_font_family_box(
     return label;
   };
   auto box = new FontFamilyBox(std::move(settings), parent);
-  update_style(*box, [&] (auto& style) {
+  update_style(*box, [] (auto& style) {
     style.get(Any() > is_a<ListItem>()).
       set(border_size(0)).
       set(vertical_padding(0));
   });
+  invalidate_descendant_layouts(*box);
   return box;
 }


### PR DESCRIPTION
Manually update the cached hint size after removing the vertical padding from ListItem to resolve the issue where the current item can't scroll to the correct position. It is related to [FontFamilyBox current list item does not scroll to viewport on initialization in TimeAndSalesPropertiesWindow](https://app.asana.com/0/1169210941620249/1205993913492188/f).