### PR TITLE
Window resize issue

### DIFF
--- a/Applications/Spire/Source/Ui/Window.cpp
+++ b/Applications/Spire/Source/Ui/Window.cpp
@@ -233,8 +233,8 @@ void Window::set_body(QWidget* body) {
 }
 
 QSize Window::adjusted_window_size(const QSize& body_size) {
-  return {body_size.width() + 2 * scale_width(1),
-    body_size.height() + m_title_bar->height() + 2 * scale_height(1)};
+  return {body_size.width() + 4 * scale_width(1),
+    body_size.height() + m_title_bar->height() + 4 * scale_height(1)};
 }
 
 void Window::on_screen_changed(QScreen* screen) {


### PR DESCRIPTION
I put two demos in demos/window_resize_issue.
1. Scratch-with-resize-issue shows what the issue is.
2. Scratch is the demo that fixed the issue.

The code of demo is as follows:
```#include <QApplication>
#include "Spire/Spire/Resources.hpp"
#include "Spire/Ui/Window.hpp"

using namespace Spire;

class CustomWindow : public Window {
  public:
    explicit CustomWindow(QWidget* parent = nullptr) : Window(parent) {
      auto body = new QWidget();
      body->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
      set_body(body);
   }
};

int main(int argc, char** argv) {
  auto application = QApplication(argc, argv);
  application.setOrganizationName(QObject::tr("Spire Trading Inc"));
  application.setApplicationName(QObject::tr("Scratch"));
  initialize_resources();
  auto window = CustomWindow();
  window.show();
  application.exec();
}```