### PR TITLE
KeyObserver adds functionality to filter out key presses.

### DIFF
--- a/Applications/Spire/Include/Spire/Ui/ComboBox.hpp
+++ b/Applications/Spire/Include/Spire/Ui/ComboBox.hpp
@@ -6,6 +6,7 @@
 #include <Beam/Collections/Trie.hpp>
 #include "Spire/Async/QtPromise.hpp"
 #include "Spire/Ui/FocusObserver.hpp"
+#include "Spire/Ui/KeyObserver.hpp"
 #include "Spire/Ui/ListView.hpp"
 #include "Spire/Ui/Ui.hpp"
 
@@ -138,6 +139,7 @@ namespace Spire {
         QWidget* m_input_focus_proxy;
         ListView* m_list_view;
         FocusObserver m_focus_observer;
+        KeyObserver m_key_observer;
         std::shared_ptr<ArrayListModel<std::any>> m_matches;
         DropDownList* m_drop_down_list;
         boost::optional<QString> m_user_query;
@@ -174,6 +176,7 @@ namespace Spire {
       void on_drop_down_current(boost::optional<int> index);
       void on_drop_down_submit(const std::any& submission);
       void on_focus(FocusObserver::State state);
+      bool on_input_key_press(QWidget& target, QKeyEvent& event);
   };
 
   /**

--- a/Applications/Spire/Include/Spire/Ui/KeyObserver.hpp
+++ b/Applications/Spire/Include/Spire/Ui/KeyObserver.hpp
@@ -1,5 +1,6 @@
 #ifndef SPIRE_KEY_OBSERVER_HPP
 #define SPIRE_KEY_OBSERVER_HPP
+#include <functional>
 #include <memory>
 #include <QKeyEvent>
 #include "Spire/Ui/Ui.hpp"
@@ -11,12 +12,21 @@ namespace Spire {
     public:
 
       /**
-       * Signals a key press.
+       * Signals a key press with the option to filter it.
+       * @param target The QWidget that received the event.
+       * @param event The QKeyEvent representing the key press.
+       * @return <code>true</code> to filter the event.
+       */
+      using FilteredKeyPressSignal =
+        Signal<bool (QWidget& target, QKeyEvent& event)>;
+
+      /**
+       * Signals a key press but does not filter it out.
        * @param target The QWidget that received the event.
        * @param event The QKeyEvent representing the key press.
        */
       using KeyPressSignal =
-        Signal<void (QWidget& target, const QKeyEvent& event)>;
+        std::function<void (QWidget& target, QKeyEvent& event)>;
 
       /**
        * Constructs a KeyObserver.
@@ -25,12 +35,16 @@ namespace Spire {
       explicit KeyObserver(QWidget& widget);
 
       /** Connects a slot to the key press signal. */
+      boost::signals2::connection connect_filtered_key_press_signal(
+        const FilteredKeyPressSignal::slot_type& slot) const;
+
+      /** Connects a slot to the key press signal. */
       boost::signals2::connection connect_key_press_signal(
-        const KeyPressSignal::slot_type& slot) const;
+        const KeyPressSignal& slot) const;
 
     private:
       struct EventFilter;
-      mutable KeyPressSignal m_key_press_signal;
+      mutable FilteredKeyPressSignal m_key_press_signal;
       std::shared_ptr<EventFilter> m_filter;
       boost::signals2::scoped_connection m_filter_connection;
   };


### PR DESCRIPTION
ComboBox uses the KeyObserver to detect ESC key and revert.