### PR TITLE
TaskKeysTableView

### DIFF
--- a/Applications/Spire/Include/Spire/KeyBindings/KeyBindings.hpp
+++ b/Applications/Spire/Include/Spire/KeyBindings/KeyBindings.hpp
@@ -13,7 +13,6 @@ namespace Spire {
   class KeyBindingsWindow;
   class OrderFieldInfoTip;
   struct OrderTaskArguments;
-  class TaskKeysTableView;
 }
 
 #endif

--- a/Applications/Spire/Include/Spire/KeyBindings/KeyBindings.hpp
+++ b/Applications/Spire/Include/Spire/KeyBindings/KeyBindings.hpp
@@ -13,6 +13,7 @@ namespace Spire {
   class KeyBindingsWindow;
   class OrderFieldInfoTip;
   struct OrderTaskArguments;
+  class TaskKeysTableView;
 }
 
 #endif

--- a/Applications/Spire/Include/Spire/KeyBindings/KeyBindingsWindow.hpp
+++ b/Applications/Spire/Include/Spire/KeyBindings/KeyBindingsWindow.hpp
@@ -19,7 +19,9 @@ namespace Spire {
        */
       explicit KeyBindingsWindow(std::shared_ptr<KeyBindingsModel> key_bindings,
         const Nexus::CountryDatabase& countries,
-        const Nexus::MarketDatabase& markets, QWidget* parent = nullptr);
+        const Nexus::MarketDatabase& markets,
+        const Nexus::DestinationDatabase& destinations,
+        QWidget* parent = nullptr);
 
     private:
       std::shared_ptr<KeyBindingsModel> m_key_bindings;

--- a/Applications/Spire/Include/Spire/KeyBindings/TaskKeysTableView.hpp
+++ b/Applications/Spire/Include/Spire/KeyBindings/TaskKeysTableView.hpp
@@ -1,0 +1,24 @@
+#ifndef SPIRE_TASK_KEYS_TABLE_VIEW_HPP
+#define SPIRE_TASK_KEYS_TABLE_VIEW_HPP
+#include <QWidget>
+#include "Spire/KeyBindings/OrderTaskArguments.hpp"
+#include "Spire/Ui/ComboBox.hpp"
+
+namespace Spire {
+
+  /**
+   * Returns a new EditableTableView for task keys.
+   * @param order_task_arguments The list of order task arguments.
+   * @param region_query_model The model used to query region matches.
+   * @param destinations The destination database to use.
+   * @param markets The market database to use.
+   * @param parent The parent widget.
+   */
+  TableView* make_task_keys_table_view(
+    std::shared_ptr<OrderTaskArgumentsListModel> order_task_arguments,
+    std::shared_ptr<ComboBox::QueryModel> region_query_model,
+    Nexus::DestinationDatabase destinations, Nexus::MarketDatabase markets,
+    QWidget* parent = nullptr);
+}
+
+#endif

--- a/Applications/Spire/Include/Spire/KeyBindings/TaskKeysTableView.hpp
+++ b/Applications/Spire/Include/Spire/KeyBindings/TaskKeysTableView.hpp
@@ -2,6 +2,7 @@
 #define SPIRE_TASK_KEYS_TABLE_VIEW_HPP
 #include "Spire/KeyBindings/OrderTaskArguments.hpp"
 #include "Spire/Ui/ComboBox.hpp"
+#include "Spire/Ui/TableView.hpp"
 
 namespace Spire {
 

--- a/Applications/Spire/Include/Spire/KeyBindings/TaskKeysTableView.hpp
+++ b/Applications/Spire/Include/Spire/KeyBindings/TaskKeysTableView.hpp
@@ -1,6 +1,5 @@
 #ifndef SPIRE_TASK_KEYS_TABLE_VIEW_HPP
 #define SPIRE_TASK_KEYS_TABLE_VIEW_HPP
-#include <QWidget>
 #include "Spire/KeyBindings/OrderTaskArguments.hpp"
 #include "Spire/Ui/ComboBox.hpp"
 

--- a/Applications/Spire/Include/Spire/Ui/KeyInputBox.hpp
+++ b/Applications/Spire/Include/Spire/Ui/KeyInputBox.hpp
@@ -3,9 +3,15 @@
 #include <QKeySequence>
 #include <QWidget>
 #include "Spire/Spire/LocalValueModel.hpp"
+#include "Spire/Styles/Stylist.hpp"
 #include "Spire/Ui/Ui.hpp"
 
 namespace Spire {
+namespace Styles {
+
+  /** Selects a prompt. */
+  using Prompt = StateSelector<void, struct PromptSelectorTag>;
+}
 
   /** A ValueModel over a QKeySequence. */
   using KeySequenceValueModel = ValueModel<QKeySequence>;

--- a/Applications/Spire/Source/KeyBindings/KeyBindingsWindow.cpp
+++ b/Applications/Spire/Source/KeyBindings/KeyBindingsWindow.cpp
@@ -1,5 +1,4 @@
 #include "Spire/KeyBindings/KeyBindingsWindow.hpp"
-#include "Nexus/Definitions/DefaultDestinationDatabase.hpp"
 #include "Spire/KeyBindings/CancelKeyBindingsForm.hpp"
 #include "Spire/KeyBindings/CancelKeyBindingsModel.hpp"
 #include "Spire/KeyBindings/InteractionsKeyBindingsForm.hpp"
@@ -12,7 +11,6 @@
 #include "Spire/Ui/Layouts.hpp"
 #include "Spire/Ui/NavigationView.hpp"
 #include "Spire/Ui/ScrollBox.hpp"
-#include "Spire/Ui/TableView.hpp"
 
 using namespace boost::signals2;
 using namespace Nexus;
@@ -22,7 +20,7 @@ using namespace Spire::Styles;
 KeyBindingsWindow::KeyBindingsWindow(
     std::shared_ptr<KeyBindingsModel> key_bindings,
     const CountryDatabase& countries, const MarketDatabase& markets,
-    QWidget* parent)
+    const DestinationDatabase& destinations, QWidget* parent)
     : Window(parent),
       m_key_bindings(std::move(key_bindings)) {
   setWindowTitle(tr("Key Bindings"));
@@ -35,8 +33,7 @@ KeyBindingsWindow::KeyBindingsWindow(
   task_keys_page->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   auto task_key_table_view = make_task_keys_table_view(
     m_key_bindings->get_order_task_arguments(),
-    std::make_shared<LocalComboBoxQueryModel>(),
-    GetDefaultDestinationDatabase(), markets);
+    std::make_shared<LocalComboBoxQueryModel>(), destinations, markets);
   enclose(*task_keys_page, *task_key_table_view);
   navigation_view->add_tab(*task_keys_page, tr("Task Keys"));
   auto cancel_keys_page =

--- a/Applications/Spire/Source/KeyBindings/KeyBindingsWindow.cpp
+++ b/Applications/Spire/Source/KeyBindings/KeyBindingsWindow.cpp
@@ -1,20 +1,76 @@
 #include "Spire/KeyBindings/KeyBindingsWindow.hpp"
+#include "Nexus/Definitions/DefaultDestinationDatabase.hpp"
+#include "Nexus/Definitions/SecuritySet.hpp"
 #include "Spire/KeyBindings/CancelKeyBindingsForm.hpp"
 #include "Spire/KeyBindings/CancelKeyBindingsModel.hpp"
 #include "Spire/KeyBindings/InteractionsKeyBindingsForm.hpp"
 #include "Spire/KeyBindings/InteractionsKeyBindingsModel.hpp"
 #include "Spire/KeyBindings/InteractionsPage.hpp"
+#include "Spire/KeyBindings/TaskKeysTableView.hpp"
 #include "Spire/Spire/Dimensions.hpp"
 #include "Spire/Ui/Box.hpp"
 #include "Spire/Ui/Button.hpp"
+#include "Spire/Ui/EmptyTableFilter.hpp"
 #include "Spire/Ui/Layouts.hpp"
 #include "Spire/Ui/NavigationView.hpp"
 #include "Spire/Ui/ScrollBox.hpp"
+#include "Spire/Ui/TableView.hpp"
 
 using namespace boost::signals2;
 using namespace Nexus;
 using namespace Spire;
 using namespace Spire::Styles;
+
+namespace {
+  auto populate_order_task_arguments() {
+    auto arguments = std::make_shared<ArrayListModel<OrderTaskArguments>>();
+    arguments->push({"Test1",
+      Region(GetDefaultMarketDatabase().FromCode(DefaultMarkets::TSX())),
+      "ALPHA", OrderType::MARKET, Side::ASK, Quantity(1),
+      TimeInForce(TimeInForce::Type::DAY), {}, QKeySequence("Ctrl+F4")});
+    arguments->push({"Test2",
+      Region(GetDefaultMarketDatabase().FromCode(DefaultMarkets::TSX())),
+      "TSX", OrderType::STOP, Side::ASK, Quantity(10),
+      TimeInForce(TimeInForce::Type::DAY), {}, QKeySequence("Ctrl+Alt+S")});
+    arguments->push({"Test3",
+      Region(DefaultCountries::US()), "NYSE",
+      OrderType::MARKET, Side::BID, Quantity(20),
+      TimeInForce(TimeInForce::Type::IOC), {}, QKeySequence("F3")});
+    return arguments;
+  }
+
+  auto populate_region_box_model() {
+    auto securities = std::vector<std::pair<std::string, std::string>>{
+      {"MSFT.NSDQ", "Microsoft Corporation"},
+      {"MG.TSX", "Magna International Inc."},
+      {"MRU.TSX", "Metro Inc."},
+      {"MFC.TSX", "Manulife Financial Corporation"},
+      {"MX.TSX", "Methanex Corporation"},
+      {"TSO.ASX", "Tesoro Resources Limited"}};
+    auto model = std::make_shared<LocalComboBoxQueryModel>();
+    for(auto& security_info : securities) {
+      auto security = *ParseWildCardSecurity(security_info.first,
+        GetDefaultMarketDatabase(), GetDefaultCountryDatabase());
+      auto region = Region(security);
+      region.SetName(security_info.second);
+      model->add(to_text(security).toLower(), region);
+      model->add(QString::fromStdString(region.GetName()).toLower(), region);
+    }
+    for(auto& market : GetDefaultMarketDatabase().GetEntries()) {
+      auto region = Region(market);
+      region.SetName(market.m_description);
+      model->add(to_text(MarketToken(market.m_code)).toLower(), region);
+      model->add(QString::fromStdString(region.GetName()).toLower(), region);
+    }
+    for(auto& country : GetDefaultCountryDatabase().GetEntries()) {
+      auto region = Region(country.m_code);
+      region.SetName(country.m_name);
+      model->add(to_text(country.m_code).toLower(), region);
+      model->add(QString::fromStdString(region.GetName()).toLower(), region);
+    }
+    return model;
+  }
+}
 
 KeyBindingsWindow::KeyBindingsWindow(
     std::shared_ptr<KeyBindingsModel> key_bindings,
@@ -30,6 +86,9 @@ KeyBindingsWindow::KeyBindingsWindow(
     QSizePolicy::Expanding, QSizePolicy::Expanding);
   auto task_keys_page = new QWidget();
   task_keys_page->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  auto task_key_table_view = make_task_keys_table_view(populate_order_task_arguments(),
+    populate_region_box_model(), GetDefaultDestinationDatabase(), markets);
+  enclose(*task_keys_page, *task_key_table_view);
   navigation_view->add_tab(*task_keys_page, tr("Task Keys"));
   auto cancel_keys_page =
     new CancelKeyBindingsForm(m_key_bindings->get_cancel_key_bindings());

--- a/Applications/Spire/Source/KeyBindings/TaskKeysTableView.cpp
+++ b/Applications/Spire/Source/KeyBindings/TaskKeysTableView.cpp
@@ -1,0 +1,413 @@
+#include "Spire/KeyBindings/TaskKeysTableView.hpp"
+#include <boost/signals2/shared_connection_block.hpp>
+#include <QKeyEvent>
+#include "Spire/Spire/ArrayListModel.hpp"
+#include "Spire/Spire/ColumnViewListModel.hpp"
+#include "Spire/Spire/Dimensions.hpp"
+#include "Spire/Spire/ListValueModel.hpp"
+#include "Spire/Spire/TableModelTransactionLog.hpp"
+#include "Spire/Spire/ValidatedValueModel.hpp"
+#include "Spire/Ui/AnyInputBox.hpp"
+#include "Spire/Ui/DestinationBox.hpp"
+#include "Spire/Ui/EditableBox.hpp"
+#include "Spire/Ui/EditableTableView.hpp"
+#include "Spire/Ui/EmptySelectionModel.hpp"
+#include "Spire/Ui/EmptyTableFilter.hpp"
+#include "Spire/Ui/KeyInputBox.hpp"
+#include "Spire/Ui/OrderTypeBox.hpp"
+#include "Spire/Ui/PopupBox.hpp"
+#include "Spire/Ui/QuantityBox.hpp"
+#include "Spire/Ui/RegionBox.hpp"
+#include "Spire/Ui/SideBox.hpp"
+#include "Spire/Ui/SingleSelectionModel.hpp"
+#include "Spire/Ui/TextBox.hpp"
+#include "Spire/Ui/TimeInForceBox.hpp"
+
+using namespace boost;
+using namespace boost::signals2;
+using namespace Nexus;
+using namespace Spire;
+
+namespace {
+  auto to_list(const OrderTaskArguments& arguments) {
+    auto list_model = std::make_shared<ArrayListModel<std::any>>();
+    list_model->push(arguments.m_name);
+    list_model->push(arguments.m_region);
+    list_model->push(arguments.m_destination);
+    list_model->push(arguments.m_order_type);
+    list_model->push(arguments.m_side);
+    list_model->push(arguments.m_quantity);
+    list_model->push(arguments.m_time_in_force);
+    list_model->push(arguments.m_additional_tags);
+    list_model->push(arguments.m_key);
+    return list_model;
+  }
+
+  auto make_quantity_modifiers() {
+    return QHash<Qt::KeyboardModifier, Quantity>(
+      {{Qt::NoModifier, 1}, {Qt::AltModifier, 5}, {Qt::ControlModifier, 10},
+       {Qt::ShiftModifier, 20}});
+  }
+
+  auto key_input_box_validator(const QKeySequence& sequence) {
+    if(sequence.count() == 0) {
+      return QValidator::Intermediate;
+    } else if(sequence.count() > 1) {
+      return QValidator::Invalid;
+    }
+    auto key = sequence[0];
+    auto modifier = key & Qt::KeyboardModifierMask;
+    auto new_key = key - modifier;
+    if(((modifier == Qt::NoModifier || modifier & Qt::ControlModifier ||
+          modifier & Qt::ShiftModifier || modifier & Qt::AltModifier) &&
+          new_key >= Qt::Key_F1 && new_key <= Qt::Key_F12) ||
+        ((modifier & Qt::ControlModifier || modifier & Qt::ShiftModifier ||
+          modifier & Qt::AltModifier) && new_key >= Qt::Key_0 &&
+          new_key <= Qt::Key_9)) {
+      return QValidator::Acceptable;
+    }
+    return QValidator::Invalid;
+  }
+
+  auto make_header_model() {
+    auto model = std::make_shared<ArrayListModel<TableHeaderItem::Model>>();
+    auto push = [&] (const QString& name, const QString& short_name) {
+      model->push({name, short_name, TableHeaderItem::Order::NONE,
+        TableFilter::Filter::UNFILTERED});
+    };
+    push(QObject::tr("Name"), QObject::tr("Name"));
+    push(QObject::tr("Region"), QObject::tr("Region"));
+    push(QObject::tr("Destination"), QObject::tr("Dest"));
+    push(QObject::tr("Order Type"), QObject::tr("Ord Type"));
+    push(QObject::tr("Side"), QObject::tr("Side"));
+    push(QObject::tr("Quantity"), QObject::tr("Qty"));
+    push(QObject::tr("Time in Force"), QObject::tr("TIF"));
+    push(QObject::tr("Tags"), QObject::tr("Tags"));
+    push(QObject::tr("Key"), QObject::tr("Key"));
+    return model;
+  }
+
+  auto make_header_widths() {
+    auto widths = std::vector<int>();
+    widths.push_back(scale_width(160));
+    widths.push_back(scale_width(80));
+    widths.push_back(scale_width(110));
+    widths.push_back(scale_width(90));
+    widths.push_back(scale_width(70));
+    widths.push_back(scale_width(70));
+    widths.push_back(scale_width(70));
+    widths.push_back(scale_width(80));
+    widths.push_back(scale_width(128));
+    return widths;
+  }
+
+  template<typename T>
+  auto to_value_model(const std::shared_ptr<TableModel>& table, int row,
+      int column) {
+    return make_list_value_model(
+      std::make_shared<ColumnViewListModel<T>>(table, column), row);
+  }
+}
+
+struct DestinationQueryModel : ComboBox::QueryModel {
+  std::shared_ptr<ValueModel<Region>> m_region_model;
+  DestinationDatabase m_destinations;
+  MarketDatabase m_markets;
+  std::unique_ptr<LocalComboBoxQueryModel> m_local_query_model;
+  scoped_connection m_region_connection;
+
+  DestinationQueryModel(std::shared_ptr<ValueModel<Region>> region_model,
+      DestinationDatabase destinations, MarketDatabase markets)
+      : m_region_model(std::move(region_model)),
+        m_destinations(std::move(destinations)),
+        m_markets(std::move(markets)),
+        m_local_query_model(std::make_unique<LocalComboBoxQueryModel>()),
+        m_region_connection(m_region_model->connect_update_signal(
+          std::bind_front(&DestinationQueryModel::on_update, this))) {
+    on_update(m_region_model->get());
+  }
+
+  std::any parse(const QString& query) override {
+    return m_local_query_model->parse(query);
+  }
+
+  QtPromise<std::vector<std::any>> submit(const QString& query) override {
+    return m_local_query_model->submit(query);
+  }
+
+  void on_update(const Region& region) {
+    auto market_set = std::unordered_set<MarketCode>();
+    for(auto& security : region.GetSecurities()) {
+      market_set.insert(security.GetMarket());
+    }
+    auto region_markets = region.GetMarkets();
+    market_set.insert(region_markets.begin(), region_markets.end());
+    for(auto& country : region.GetCountries()) {
+      auto markets = m_markets.FromCountry(country);
+      for(auto& market : markets) {
+        market_set.insert(market.m_code);
+      }
+    }
+    m_local_query_model = std::make_unique<LocalComboBoxQueryModel>();
+    auto destinations = m_destinations.SelectEntries(
+      [] (auto& value) { return true; });
+    for(auto& destination : destinations) {
+      for(auto& market : destination.m_markets) {
+        if(market_set.contains(market)) {
+          m_local_query_model->add(to_text(destination.m_id).toLower(),
+            destination);
+          break;
+        }
+      }
+    }
+  }
+};
+
+struct DestinationValueModel : ValueModel<Destination> {
+  std::shared_ptr<ValueModel<Destination>> m_source;
+  std::shared_ptr<DestinationQueryModel> m_query_model;
+  scoped_connection m_connection;
+
+  DestinationValueModel(std::shared_ptr<ValueModel<Destination>> source,
+    std::shared_ptr<DestinationQueryModel> query_model)
+    : m_source(std::move(source)),
+      m_query_model(std::move(query_model)),
+      m_connection(m_query_model->m_region_model->connect_update_signal(
+        std::bind_front(&DestinationValueModel::on_update, this))) {
+    on_update(m_query_model->m_region_model->get());
+  }
+
+  QValidator::State get_state() const override {
+    return m_source->get_state();
+  }
+
+  const Destination& get() const override {
+    return m_source->get();
+  }
+
+  QValidator::State test(const Destination& value) const override {
+    return m_source->test(value);
+  }
+
+  QValidator::State set(const Destination& value) override {
+    return m_source->set(value);
+  }
+
+  connection connect_update_signal(
+    const typename UpdateSignal::slot_type& slot) const override {
+    return m_source->connect_update_signal(slot);
+  }
+
+  void on_update(const Region& region) {
+    if(!get().empty() && !m_query_model->parse(to_text(get())).has_value()) {
+      set(Destination());
+    }
+  }
+};
+
+struct OrderTaskTableModel : TableModel {
+  enum class Column {
+    NAME,
+    REGION,
+    DESTINATION,
+    ORDER_TYPE,
+    SIDE,
+    QUANTITY,
+    TIME_IN_FORCE,
+    TAGS,
+    KEY
+  };
+  static const auto COLUMN_SIZE = 9;
+  std::shared_ptr<OrderTaskArgumentsListModel> m_source;
+  TableModelTransactionLog m_transaction;
+  scoped_connection m_source_connection;
+
+  explicit OrderTaskTableModel(
+    std::shared_ptr<OrderTaskArgumentsListModel> source)
+    : m_source(std::move(source)),
+      m_source_connection(m_source->connect_operation_signal(
+        std::bind_front(&OrderTaskTableModel::on_operation, this))) {}
+
+  int get_row_size() const override {
+    return m_source->get_size();
+  }
+
+  int get_column_size() const override {
+    return COLUMN_SIZE;
+  }
+
+  AnyRef at(int row, int column) const override {
+    if(column < 0 || column >= get_column_size()) {
+      throw std::out_of_range("The column is out of range.");
+    }
+    return extract_field(m_source->get(row), static_cast<Column>(column));
+  }
+
+  QValidator::State set(int row, int column, const std::any& value) override {
+    if(column < 0 || column >= get_column_size()) {
+      throw std::out_of_range("The column is out of range.");
+    }
+    auto column_index = static_cast<Column>(column);
+    auto arguments = m_source->get(row);
+    auto previous = to_any(extract_field(arguments, column_index));
+    if(column_index == Column::NAME) {
+      arguments.m_name = std::any_cast<QString>(value);
+    } else if(column_index == Column::REGION) {
+      arguments.m_region = std::any_cast<Region>(value);
+    } else if(column_index == Column::DESTINATION) {
+      arguments.m_destination = std::any_cast<Destination>(value);
+    } else if(column_index == Column::ORDER_TYPE) {
+      arguments.m_order_type = std::any_cast<OrderType>(value);
+    } else if(column_index == Column::SIDE) {
+      arguments.m_side = std::any_cast<Side>(value);
+    } else if(column_index == Column::QUANTITY) {
+      arguments.m_quantity = std::any_cast<optional<Quantity>>(value);
+    } else if(column_index == Column::TIME_IN_FORCE) {
+      arguments.m_time_in_force = std::any_cast<TimeInForce>(value);
+    } else if(column_index == Column::TAGS) {
+      arguments.m_additional_tags = {};
+    } else if(column_index == Column::KEY) {
+      arguments.m_key = std::any_cast<QKeySequence>(value);
+    }
+    auto blocker = shared_connection_block(m_source_connection);
+    auto result = m_source->set(row, arguments);
+    m_transaction.push(
+      TableModel::UpdateOperation(row, column, previous, value));
+    return result;
+  }
+
+  QValidator::State remove(int row) override {
+    return m_source->remove(row);
+  }
+
+  connection connect_operation_signal(
+      const OperationSignal::slot_type& slot) const override {
+    return m_transaction.connect_operation_signal(slot);
+  }
+
+  AnyRef extract_field(const OrderTaskArguments& arguments,
+      Column column) const {
+    if(column == Column::NAME) {
+      return arguments.m_name;
+    } else if(column == Column::REGION) {
+      return arguments.m_region;
+    } else if(column == Column::DESTINATION) {
+      return arguments.m_destination;
+    } else if(column == Column::ORDER_TYPE) {
+      return arguments.m_order_type;
+    } else if(column == Column::SIDE) {
+      return arguments.m_side;
+    } else if(column == Column::QUANTITY) {
+      return arguments.m_quantity;
+    } else if(column == Column::TIME_IN_FORCE) {
+      return arguments.m_time_in_force;
+    } else if(column == Column::TAGS) {
+      return arguments.m_additional_tags;
+    } else if(column == Column::KEY) {
+      return arguments.m_key;
+    }
+    return {};
+  }
+
+  void on_operation(const OrderTaskArgumentsListModel::Operation& operation) {
+    visit(operation,
+      [&] (const OrderTaskArgumentsListModel::AddOperation& operation) {
+        m_transaction.push(TableModel::AddOperation(operation.m_index,
+          to_list(operation.get_value())));
+      },
+      [&] (const OrderTaskArgumentsListModel::MoveOperation& operation) {
+        m_transaction.push(TableModel::MoveOperation(
+          operation.m_source, operation.m_destination));
+      },
+      [&] (const OrderTaskArgumentsListModel::RemoveOperation& operation) {
+        m_transaction.push(TableModel::RemoveOperation(operation.m_index,
+          to_list(operation.get_value())));
+      },
+      [&] (const OrderTaskArgumentsListModel::UpdateOperation& operation) {
+        for(auto i = 0; i < COLUMN_SIZE; ++i) {
+          m_transaction.push(TableModel::UpdateOperation(operation.m_index, i,
+            to_any(
+              extract_field(operation.get_previous(), static_cast<Column>(i))),
+            to_any(
+              extract_field(operation.get_value(), static_cast<Column>(i)))));
+        }
+      });
+  }
+};
+
+EditableBox* make_table_item(
+    std::shared_ptr<ComboBox::QueryModel> region_query_model,
+    const DestinationDatabase& destinations, const MarketDatabase& markets,
+      const std::shared_ptr<TableModel>& table, int row, int column) {
+  auto column_id = static_cast<OrderTaskTableModel::Column>(column);
+  auto input_box = [&] () -> AnyInputBox* {
+    if(column_id == OrderTaskTableModel::Column::NAME) {
+      return new AnyInputBox(*new TextBox(
+        to_value_model<QString>(table, row, column)));
+    } else if(column_id == OrderTaskTableModel::Column::REGION) {
+      return new AnyInputBox(*new RegionBox(region_query_model,
+        to_value_model<Region>(table, row, column)));
+    } else if(column_id == OrderTaskTableModel::Column::DESTINATION) {
+      auto region_model = to_value_model<Region>(table, row,
+        static_cast<int>(OrderTaskTableModel::Column::REGION));
+      auto query_model = std::make_shared<DestinationQueryModel>(
+        std::move(region_model), destinations, markets);
+      auto current_model = std::make_shared<DestinationValueModel>(
+        to_value_model<Destination>(table, row, column), query_model);
+      return new AnyInputBox(*new DestinationBox(std::move(query_model),
+        std::move(current_model)));
+    } else if(column_id == OrderTaskTableModel::Column::ORDER_TYPE) {
+      return new AnyInputBox(*make_order_type_box(
+        to_value_model<OrderType>(table, row, column)));
+    } else if(column_id == OrderTaskTableModel::Column::SIDE) {
+      return new AnyInputBox(*make_side_box(
+        to_value_model<Side>(table, row, column)));
+    } else if(column_id == OrderTaskTableModel::Column::QUANTITY) {
+      return new AnyInputBox(*new QuantityBox(
+        std::make_shared<ScalarValueModelDecorator<optional<Quantity>>>(
+          to_value_model<optional<Quantity>>(table, row, column)),
+        make_quantity_modifiers()));
+    } else if(column_id == OrderTaskTableModel::Column::TIME_IN_FORCE) {
+      return new AnyInputBox(*make_time_in_force_box(
+        to_value_model<TimeInForce>(table, row, column)));
+    } else if(column_id == OrderTaskTableModel::Column::TAGS) {
+      return new AnyInputBox(*make_label(""));
+    } else if(column_id == OrderTaskTableModel::Column::KEY) {
+      return new AnyInputBox(*new KeyInputBox(
+        make_validated_value_model<QKeySequence>(&key_input_box_validator,
+          to_value_model<QKeySequence>(table, row, column))));
+    } 
+    return nullptr;
+  }();
+  if(!input_box) {
+    return nullptr;
+  }
+  if(column_id == OrderTaskTableModel::Column::KEY) {
+    return new EditableBox(*input_box, [] (const auto& key) {
+      return key_input_box_validator(key) == QValidator::Acceptable;
+    });
+  }
+  return new EditableBox(*input_box);;
+}
+
+TableView* Spire::make_task_keys_table_view(
+    std::shared_ptr<OrderTaskArgumentsListModel> order_task_arguments,
+    std::shared_ptr<ComboBox::QueryModel> region_query_model,
+    Nexus::DestinationDatabase destinations, Nexus::MarketDatabase markets,
+    QWidget* parent) {
+  auto table_view = new EditableTableView(
+    std::make_shared<OrderTaskTableModel>(order_task_arguments),
+    make_header_model(), std::make_shared<EmptyTableFilter>(),
+    std::make_shared<LocalValueModel<optional<TableIndex>>>(),
+    std::make_shared<TableSelectionModel>(
+      std::make_shared<TableEmptySelectionModel>(),
+      std::make_shared<ListSingleSelectionModel>(),
+      std::make_shared<ListEmptySelectionModel>()),
+    std::bind_front(&make_table_item, region_query_model, destinations,
+      markets), {});
+  auto widths = make_header_widths();
+  for(auto i = 0; i < std::ssize(widths); ++i) {
+    table_view->get_header().get_widths()->set(i + 1, widths[i]);
+  }
+  return table_view;
+}

--- a/Applications/Spire/Source/KeyBindings/TaskKeysTableView.cpp
+++ b/Applications/Spire/Source/KeyBindings/TaskKeysTableView.cpp
@@ -417,6 +417,9 @@ class EditablePopupBox : public EditableBox {
       m_popup_box->setAttribute(Qt::WA_TransparentForMouseEvents);
       layout()->addWidget(m_popup_box);
       m_tip_window = find_tip_window(input_box);
+      if(auto proxy = find_focus_proxy(input_box)) {
+        proxy->installEventFilter(this);
+      }
       m_editable_box->installEventFilter(this);
     }
 
@@ -428,6 +431,17 @@ class EditablePopupBox : public EditableBox {
           } else {
             unmatch(*this, PopUp());
           }
+        }
+      } else if(event->type() == QEvent::KeyPress) {
+        auto& key_event = *static_cast<QKeyEvent*>(event);
+        if(key_event.key() == Qt::Key_Tab) {
+          setFocus();
+          focusNextChild();
+          return true;
+        } else if(key_event.key() == Qt::Key_Backtab) {
+          setFocus();
+          focusPreviousChild();
+          return true;
         }
       }
       return EditableBox::eventFilter(watched, event);

--- a/Applications/Spire/Source/KeyBindings/TaskKeysTableView.cpp
+++ b/Applications/Spire/Source/KeyBindings/TaskKeysTableView.cpp
@@ -1,6 +1,5 @@
 #include "Spire/KeyBindings/TaskKeysTableView.hpp"
 #include <boost/signals2/shared_connection_block.hpp>
-#include <QKeyEvent>
 #include "Spire/Spire/ArrayListModel.hpp"
 #include "Spire/Spire/ColumnViewListModel.hpp"
 #include "Spire/Spire/Dimensions.hpp"
@@ -169,11 +168,11 @@ struct DestinationValueModel : ValueModel<Destination> {
   scoped_connection m_connection;
 
   DestinationValueModel(std::shared_ptr<ValueModel<Destination>> source,
-    std::shared_ptr<DestinationQueryModel> query_model)
-    : m_source(std::move(source)),
-      m_query_model(std::move(query_model)),
-      m_connection(m_query_model->m_region_model->connect_update_signal(
-        std::bind_front(&DestinationValueModel::on_update, this))) {
+      std::shared_ptr<DestinationQueryModel> query_model)
+      : m_source(std::move(source)),
+        m_query_model(std::move(query_model)),
+        m_connection(m_query_model->m_region_model->connect_update_signal(
+          std::bind_front(&DestinationValueModel::on_update, this))) {
     on_update(m_query_model->m_region_model->get());
   }
 
@@ -194,7 +193,7 @@ struct DestinationValueModel : ValueModel<Destination> {
   }
 
   connection connect_update_signal(
-    const typename UpdateSignal::slot_type& slot) const override {
+      const typename UpdateSignal::slot_type& slot) const override {
     return m_source->connect_update_signal(slot);
   }
 
@@ -338,7 +337,7 @@ struct OrderTaskTableModel : TableModel {
 EditableBox* make_table_item(
     std::shared_ptr<ComboBox::QueryModel> region_query_model,
     const DestinationDatabase& destinations, const MarketDatabase& markets,
-      const std::shared_ptr<TableModel>& table, int row, int column) {
+    const std::shared_ptr<TableModel>& table, int row, int column) {
   auto column_id = static_cast<OrderTaskTableModel::Column>(column);
   auto input_box = [&] () -> AnyInputBox* {
     if(column_id == OrderTaskTableModel::Column::NAME) {

--- a/Applications/Spire/Source/KeyBindings/TaskKeysTableView.cpp
+++ b/Applications/Spire/Source/KeyBindings/TaskKeysTableView.cpp
@@ -559,6 +559,8 @@ TableView* Spire::make_task_keys_table_view(
       set(border_color(QColor(Qt::transparent)));
     style.get(Any() > is_a<EditablePopupBox>() > ReadOnly()).
       set(horizontal_padding(scale_width(8)));
+    style.get(Any() > is_a<DecimalBox>()).
+      set(TextAlign(Qt::Alignment(Qt::AlignRight)));
   });
   return table_view;
 }

--- a/Applications/Spire/Source/KeyBindings/TaskKeysTableView.cpp
+++ b/Applications/Spire/Source/KeyBindings/TaskKeysTableView.cpp
@@ -392,10 +392,10 @@ EditableBox* make_table_item(
   }();
   if(column_id == Column::KEY) {
     return new EditableBox(*input_box, [] (const auto& key) {
-      return key_input_box_validator(key) == QValidator::Acceptable;
+      return key_input_box_validator(key) != QValidator::Invalid;
     });
   }
-  return new EditableBox(*input_box);;
+  return new EditableBox(*input_box);
 }
 
 TableView* Spire::make_task_keys_table_view(

--- a/Applications/Spire/Source/KeyBindings/TaskKeysTableView.cpp
+++ b/Applications/Spire/Source/KeyBindings/TaskKeysTableView.cpp
@@ -471,6 +471,7 @@ class EditablePopupBox : public EditableBox {
       }
       m_is_processing_key = true;
       QCoreApplication::sendEvent(&m_popup_box->get_body(), event);
+      m_popup_box->get_body().setFocus();
       m_is_processing_key = false;
     }
 

--- a/Applications/Spire/Source/KeyBindings/TaskKeysTableView.cpp
+++ b/Applications/Spire/Source/KeyBindings/TaskKeysTableView.cpp
@@ -146,7 +146,7 @@ struct DestinationQueryModel : ComboBox::QueryModel {
   std::shared_ptr<ValueModel<Region>> m_region_model;
   DestinationDatabase m_destinations;
   MarketDatabase m_markets;
-  std::unique_ptr<LocalComboBoxQueryModel> m_local_query_model;
+  optional<LocalComboBoxQueryModel> m_local_query_model;
   scoped_connection m_region_connection;
 
   DestinationQueryModel(std::shared_ptr<ValueModel<Region>> region_model,
@@ -154,7 +154,6 @@ struct DestinationQueryModel : ComboBox::QueryModel {
       : m_region_model(std::move(region_model)),
         m_destinations(std::move(destinations)),
         m_markets(std::move(markets)),
-        m_local_query_model(std::make_unique<LocalComboBoxQueryModel>()),
         m_region_connection(m_region_model->connect_update_signal(
           std::bind_front(&DestinationQueryModel::on_update, this))) {
     on_update(m_region_model->get());
@@ -181,7 +180,7 @@ struct DestinationQueryModel : ComboBox::QueryModel {
         market_set.insert(market.m_code);
       }
     }
-    m_local_query_model = std::make_unique<LocalComboBoxQueryModel>();
+    m_local_query_model.emplace();
     auto destinations = m_destinations.SelectEntries(
       [] (auto& value) { return true; });
     for(auto& destination : destinations) {

--- a/Applications/Spire/Source/KeyBindingsUiTester/main.cpp
+++ b/Applications/Spire/Source/KeyBindingsUiTester/main.cpp
@@ -3,6 +3,7 @@
 #include <QTextEdit>
 #include <QVBoxLayout>
 #include "Nexus/Definitions/DefaultCountryDatabase.hpp"
+#include "Nexus/Definitions/DefaultDestinationDatabase.hpp"
 #include "Nexus/Definitions/DefaultMarketDatabase.hpp"
 #include "Spire/KeyBindings/HotkeyOverride.hpp"
 #include "Spire/KeyBindings/KeyBindingsWindow.hpp"
@@ -20,7 +21,7 @@ int main(int argc, char** argv) {
   auto key_bindings =
     std::make_shared<KeyBindingsModel>(GetDefaultMarketDatabase());
   auto window = KeyBindingsWindow(key_bindings, GetDefaultCountryDatabase(),
-    GetDefaultMarketDatabase());
+    GetDefaultMarketDatabase(), GetDefaultDestinationDatabase());
   window.show();
   auto hotkey_override = HotkeyOverride();
   application.exec();

--- a/Applications/Spire/Source/Toolbar/ToolbarController.cpp
+++ b/Applications/Spire/Source/Toolbar/ToolbarController.cpp
@@ -272,7 +272,8 @@ void ToolbarController::open_key_bindings_window() {
   }
   m_key_bindings_window = std::make_unique<KeyBindingsWindow>(
     m_user_profile->GetKeyBindings(), m_user_profile->GetCountryDatabase(),
-    m_user_profile->GetMarketDatabase());
+    m_user_profile->GetMarketDatabase(),
+    m_user_profile->GetDestinationDatabase());
   m_key_bindings_window->installEventFilter(m_event_filter.get());
   m_key_bindings_window->show();
 }

--- a/Applications/Spire/Source/Ui/EditableTableView.cpp
+++ b/Applications/Spire/Source/Ui/EditableTableView.cpp
@@ -9,6 +9,7 @@
 #include "Spire/Ui/Button.hpp"
 #include "Spire/Ui/EditableBox.hpp"
 #include "Spire/Ui/Icon.hpp"
+#include "Spire/Ui/KeyInputBox.hpp"
 #include "Spire/Ui/TableItem.hpp"
 #include "Spire/Ui/TextBox.hpp"
 
@@ -25,10 +26,10 @@ namespace {
   auto TABLE_VIEW_STYLE() {
     auto style = StyleSheet();
     style.get(Any() > is_a<TableItem>() >
-        (ReadOnly() && !(+Any() << is_a<ListItem>()))).
+        (ReadOnly() && !(+Any() << is_a<ListItem>()) && !Prompt())).
       set(horizontal_padding(scale_width(8)));
     style.get(Any() > is_a<TableItem>() > ReadOnly() >
-        (is_a<TextBox>() && !(+Any() << is_a<ListItem>()))).
+        (is_a<TextBox>() && !(+Any() << is_a<ListItem>()) && !Prompt())).
       set(horizontal_padding(scale_width(8)));
     style.get((Any() > Editing()) << Current()).
       set(border_color(QColor(Qt::transparent)));

--- a/Applications/Spire/Source/Ui/KeyInputBox.cpp
+++ b/Applications/Spire/Source/Ui/KeyInputBox.cpp
@@ -237,6 +237,7 @@ void KeyInputBox::set_status(Status status) {
     clear(layout);
     layout.setSpacing(0);
     auto prompt = make_label(tr("Enter Keys"));
+    match(*prompt, Prompt());
     prompt->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     prompt->set_read_only(true);
     prompt->setDisabled(true);


### PR DESCRIPTION
I have put a demo to demos/task_key_table_view.
The functions `populate_xxx` in KeyBindingsWindow.cpp are used for testing.

I am currently facing the challenge in adding a PopupBox to the EditableTableView. In the current implementation, the RegionBox is wrapped by the AnyInputBox, which in turn is wrapped by the EditableBox. This EditableBox is then passed to the ViewBuilder of the EditableTableView to construct a cell. However, this structure presents difficulties in integrating a PopupBox seamlessly.

If the PopupBox encapsulates the RegionBox directly, a compatibility issue arises: the AnyInputBox cannot accept the PopupBox since the PopupBox lacks the necessary interfaces such as the Submit signal and read-only related interfaces. Although one potential solution to implement a PopupRegionBox can address this interface compatible issue, it poses another challenge. When EditableBox wraps the PopupRegionBox, the act of popping up the PopupRegionBox will trigger a editing end signal, as the popped component gets focus, so the RegionBox can’t trigger the editing state in the popup status.

Alternatively, if the PopupBox wraps the EditableBox, it could address the issues mentioned above. However this approach will break the signature of the ViewBuilder. The ViewBuilder in EditableTableView returns the pointer to the EditableBox, not a pointer to the QWidget.