### PR TITLE
Crash with the PopupBox

### DIFF
--- a/Applications/Spire/Source/Ui/PopupBox.cpp
+++ b/Applications/Spire/Source/Ui/PopupBox.cpp
@@ -165,6 +165,7 @@ void PopupBox::on_body_focus(FocusObserver::State state) {
     m_body->setMinimumWidth(0);
     m_body->setMaximumWidth(QWIDGETSIZE_MAX);
     layout()->addWidget(m_body);
+    setFocusProxy(m_body);
   }
 }
 
@@ -172,9 +173,10 @@ void PopupBox::on_focus(FocusObserver::State state) {
   if(state != FocusObserver::State::NONE && !has_popped_up()) {
     update_window();
     m_last_size = size();
-    m_body->hide();
     {
       auto blocker = shared_connection_block(m_focus_connection);
+      setFocusProxy(nullptr);
+      setFocus();
       m_body->setParent(m_window);
     }
     layout()->removeWidget(m_body);

--- a/Applications/Spire/Source/UiViewer/StandardUiProfiles.cpp
+++ b/Applications/Spire/Source/UiViewer/StandardUiProfiles.cpp
@@ -3508,7 +3508,8 @@ UiProfile Spire::make_popup_box_profile() {
     size_policy_property));
   auto profile = UiProfile("PopupBox", properties, [] (auto& profile) {
     auto popup_boxes = std::vector<PopupBox*>();
-    auto grid_layout = new QGridLayout();
+    auto widget = new QWidget();
+    auto grid_layout = new QGridLayout(widget);
     grid_layout->setSpacing(0);
     for(auto i = 0; i < 5; ++i) {
       for(auto j = 0; j < 3; ++j) {
@@ -3543,17 +3544,11 @@ UiProfile Spire::make_popup_box_profile() {
         }
       }
     }
-    auto widget = new QWidget();
-    auto layout = make_hbox_layout(widget);
-    layout->addStretch(1);
-    auto vertical_layout = make_vbox_layout();
-    vertical_layout->addStretch(1);
-    vertical_layout->addLayout(grid_layout);
-    vertical_layout->addStretch(1);
-    layout->addLayout(vertical_layout, 5);
-    layout->addStretch(1);
-    widget->setMinimumSize(scale(200, 200));
-    auto& horizontal_size_policy = get<int>("horizontal_size_policy", profile.get_properties());
+    grid_layout->setColumnMinimumWidth(0, scale_width(30));
+    grid_layout->setColumnMinimumWidth(1, scale_width(120));
+    grid_layout->setColumnMinimumWidth(2, scale_width(100));
+    auto& horizontal_size_policy = get<int>("horizontal_size_policy",
+      profile.get_properties());
     horizontal_size_policy.connect_changed_signal([=] (auto value) {
       for(auto box : popup_boxes) {
         auto policy = box->sizePolicy();
@@ -3567,7 +3562,8 @@ UiProfile Spire::make_popup_box_profile() {
         box->setSizePolicy(policy);
       }
     });
-    auto& vertical_size_policy = get<int>("vertical_size_policy", profile.get_properties());
+    auto& vertical_size_policy = get<int>("vertical_size_policy",
+      profile.get_properties());
     vertical_size_policy.connect_changed_signal([=] (auto value) {
       for(auto box : popup_boxes) {
         auto policy = box->sizePolicy();


### PR DESCRIPTION
The crash was caused by reentrancy on FocusObserver. The solution is to avoid the reentrancy when changing the body's parent while the body is popping up.