### PR TITLE
Updated ComboBox and TagComboBox to synchronize the submission with c…

### DIFF
--- a/Applications/Spire/Source/Ui/ComboBox.cpp
+++ b/Applications/Spire/Source/Ui/ComboBox.cpp
@@ -489,6 +489,11 @@ void AnyComboBox::on_focus(FocusObserver::State state) {
         m_data->m_input_focus_proxy, &focus_out_event);
     }
     submit(any_cast<QString>(m_input_box->get_current()->get()), true);
+  } else if(state != FocusObserver::State::NONE && m_data) {
+    m_data->m_submission = to_any(m_current->get());
+    if(m_data->m_submission.has_value()) {
+      m_data->m_submission_text = to_text(m_data->m_submission);
+    }
   }
 }
 

--- a/Applications/Spire/Source/Ui/TagComboBox.cpp
+++ b/Applications/Spire/Source/Ui/TagComboBox.cpp
@@ -296,6 +296,9 @@ void AnyTagComboBox::on_focus(FocusObserver::State state) {
     } else {
       push_combo_box();
     }
+  } else {
+    copy_list_model(get_current(), m_submission);
+    m_is_modified = false;
   }
 }
 


### PR DESCRIPTION
…urrent when it gets focus. This allows it to be recycled when it's used in a ListView or TableView without breaking any existing functionality.