### PR TITLE
RegionBox vertical layout shift

### DIFF
--- a/Applications/Spire/Source/KeyBindings/TaskKeysTableView.cpp
+++ b/Applications/Spire/Source/KeyBindings/TaskKeysTableView.cpp
@@ -246,9 +246,7 @@ namespace {
           } else if(column_id == OrderTaskColumns::REGION) {
             auto current = make_proxy.operator ()<Region>();
             auto region_box = new RegionBox(m_regions, current);
-            region_box->setFixedHeight(scale_height(25));
-            region_box->setSizePolicy(
-              QSizePolicy::Preferred, QSizePolicy::Fixed);
+            region_box->setFixedHeight(region_box->minimumSizeHint().height());
             return {new EditableBox(*region_box),
               std::make_shared<ItemState>(current)};
           } else if(column_id == OrderTaskColumns::DESTINATION) {


### PR DESCRIPTION
It is a fix of [KeyBindings RegionBox vertical layout shift on edit](https://app.asana.com/1/1124513426775746/project/1198733135213649/task/1209705158782142?focus=true).