### PR TITLE
The proposal for Button handling the Space key press 

### DIFF
--- a/Applications/Spire/Source/Ui/Button.cpp
+++ b/Applications/Spire/Source/Ui/Button.cpp
@@ -44,6 +44,9 @@ void Button::keyPressEvent(QKeyEvent* event) {
       event->modifiers() == Qt::NoModifier && !event->isAutoRepeat()) {
     m_click_signal();
     return;
+  } else if(event->key() == Qt::Key_Space && !event->isAutoRepeat()) {
+    event->accept();
+    return;
   }
   QWidget::keyPressEvent(event);
 }


### PR DESCRIPTION
Since `Button` uses `PressObserver` to handle the Space key press, and `PressObserver` always returns `false` from `QObject::eventFilter`, it lacks a mechanism to stop the key event from being dispatched to other buttons within the same component after one button has already handled it. As a result, multiple buttons in the same component hierarchy may respond to the Space key press, leading to unintended behavior.

For example, consider a list item within a `ContextMenu` that contains a `CheckBox`. The `CheckBox` has its own `Button`, and the list item also includes a `Button`. When the user presses Space, the `CheckBox` handles the event, but the list item also processes it, changing CheckBox’s checked state and closing the menu.

I think that the correct approach for the `Button` is to accept the Space key event once it has handled it, preventing the event from being dispatched to buttons in ancestor widgets. This behavior would be consistent with how `Button` handles mouse press events, where the event is marked as accepted upon handling.

This update is proposed to address an issue where a `TargetMenuItem` containing a `CheckBox` gets checked and the menu closes when the user presses Space. The expected behavior is that the `CheckBox` is checked while the menu remains visible.