### PR TITLE
Fix dangling `this` in TagBox editing-slot cleanup lambda.

### DIFF
--- a/Applications/Spire/Source/Ui/TagBox.cpp
+++ b/Applications/Spire/Source/Ui/TagBox.cpp
@@ -167,8 +167,8 @@ struct TagBox::TagItemBuilder {
     if(index == list->get_size() - 1) {
       auto box = new QWidget();
       enclose(*box, *m_tag_box->m_text_box);
-      connect(box, &QObject::destroyed, m_tag_box, [=] {
-        m_tag_box->m_text_box->setParent(m_tag_box);
+      connect(box, &QObject::destroyed, m_tag_box, [tag_box = m_tag_box] {
+        tag_box->m_text_box->setParent(tag_box);
       });
       return box;
     }


### PR DESCRIPTION
Capture m_tag_box by value in the destroyed-signal lambda; the implicit [=] capture of `this` dangles because TagItemBuilder is destructed before the box it created (the recycler's pool drains the box widgets inside ~RecycledListViewItemBuilder, by which point the TagItemBuilder held inside it has already been destroyed by member-destruction order).