### PR TITLE
Crash on TextBox with placeholder destruction.

### DIFF
--- a/Applications/Spire/Include/Spire/Ui/TextBox.hpp
+++ b/Applications/Spire/Include/Spire/Ui/TextBox.hpp
@@ -184,6 +184,7 @@ namespace Styles {
       BoxPainter m_box_painter;
       boost::signals2::scoped_connection m_style_connection;
       boost::signals2::scoped_connection m_current_connection;
+      boost::signals2::scoped_connection m_placeholder_style_connection;
       mutable QSize m_size_hint;
 
       void elide_text();

--- a/Applications/Spire/Source/Ui/TextBox.cpp
+++ b/Applications/Spire/Source/Ui/TextBox.cpp
@@ -197,8 +197,9 @@ class TextBox::LineEdit : public QLineEdit {
       QWidget::setTabOrder(m_text_box, this);
       m_text_box->setFocusProxy(this);
       enclose(*m_text_box, *this);
-      m_placeholder_style_connection = connect_style_signal(*m_text_box,
-        Placeholder(), std::bind_front(&LineEdit::on_placeholder_style, this));
+      m_text_box->m_placeholder_style_connection = connect_style_signal(
+        *m_text_box, Placeholder(),
+        std::bind_front(&LineEdit::on_placeholder_style, this));
       on_placeholder_style();
     }
 
@@ -353,7 +354,6 @@ class TextBox::LineEdit : public QLineEdit {
     bool m_has_update;
     scoped_connection m_current_connection;
     scoped_connection m_highlight_connection;
-    scoped_connection m_placeholder_style_connection;
 
     void elide_placeholder_text() {
       m_elided_placeholder =


### PR DESCRIPTION
The placeholder style signal could fire against a partially destroyed `TextBox` after the current model has already been destroyed, causing an access violation in `LineEdit::is_placeholder_visible`. Before commit `6d53318c6`, `LineEdit` and `TextBox` shared the current model, ensuring that the model remained valid during destruction.