### PR TITLE
Split TagBox into AnyTagBox base and TextBox-backed TagBox.

### DIFF
--- a/Applications/Spire/Include/Spire/Ui/TagBox.hpp
+++ b/Applications/Spire/Include/Spire/Ui/TagBox.hpp
@@ -42,10 +42,10 @@ namespace Spire {
       const AnyRef& get_submission() const;
 
       /** Returns the input box. */
-      AnyInputBox& get_input_box();
+      const AnyInputBox& get_input_box() const;
 
       /** Returns the input box. */
-      const AnyInputBox& get_input_box() const;
+      AnyInputBox& get_input_box();
 
       /** Sets the placeholder text. */
       void set_placeholder(const QString& placeholder);

--- a/Applications/Spire/Include/Spire/Ui/TagBox.hpp
+++ b/Applications/Spire/Include/Spire/Ui/TagBox.hpp
@@ -17,6 +17,9 @@ namespace Spire {
   class AnyTagBox : public QWidget {
     public:
 
+      /** The type of signal emitted when the input is submitted. */
+      using SubmitSignal = AnyInputBox::SubmitSignal;
+
       /**
        * Constructs an AnyTagBox.
        * @param tags The list model which holds a list of tags.
@@ -28,6 +31,15 @@ namespace Spire {
 
       /** Returns the list of tags. */
       const std::shared_ptr<AnyListModel>& get_tags() const;
+
+      /** Returns the current value model. */
+      const std::shared_ptr<AnyValueModel>& get_current() const;
+
+      /** Returns the highlight model. */
+      const std::shared_ptr<HighlightModel>& get_highlight() const;
+
+      /** Returns the last submission. */
+      const AnyRef& get_submission() const;
 
       /** Returns the input box. */
       AnyInputBox& get_input_box();
@@ -47,6 +59,10 @@ namespace Spire {
        *        read-only.
        */
       void set_read_only(bool is_read_only);
+
+      /** Connects a slot to the SubmitSignal. */
+      boost::signals2::connection connect_submit_signal(
+        const SubmitSignal::slot_type& slot) const;
 
       QSize minimumSizeHint() const override;
       QSize sizeHint() const override;
@@ -142,6 +158,9 @@ namespace Spire {
 
       /** Returns the highlight model. */
       const std::shared_ptr<HighlightModel>& get_highlight() const;
+
+      /** Returns the last submission. */
+      const QString& get_submission() const;
 
       /** Connects a slot to the SubmitSignal. */
       boost::signals2::connection connect_submit_signal(

--- a/Applications/Spire/Include/Spire/Ui/TagBox.hpp
+++ b/Applications/Spire/Include/Spire/Ui/TagBox.hpp
@@ -1,63 +1,66 @@
 #ifndef SPIRE_TAG_BOX_HPP
 #define SPIRE_TAG_BOX_HPP
 #include <QWidget>
+#include "Spire/Ui/AnyInputBox.hpp"
 #include "Spire/Ui/FocusObserver.hpp"
+#include "Spire/Ui/GlobalPositionObserver.hpp"
 #include "Spire/Ui/ListView.hpp"
 #include "Spire/Ui/TextBox.hpp"
 
 namespace Spire {
-  class GlobalPositionObserver;
   class InfoTip;
   class ScrollableListBox;
   class ScrollBar;
   class TextAreaBox;
 
-  /** Displays a list of tags within a box. */
-  class TagBox : public QWidget {
+  /** A tag-list widget whose input is AnyInputBox. */
+  class AnyTagBox : public QWidget {
     public:
 
-      /** Signals that the current value in the TextBox is being submitted. */
-      using SubmitSignal = TextBox::SubmitSignal;
-
       /**
-       * Constructs a TagBox.
+       * Constructs an AnyTagBox.
        * @param tags The list model which holds a list of tags.
-       * @param current The current text's model.
+       * @param input_box The input box to use. AnyTagBox takes ownership.
        * @param parent The parent widget.
        */
-      TagBox(std::shared_ptr<AnyListModel> tags,
-        std::shared_ptr<TextModel> current, QWidget* parent = nullptr);
+      AnyTagBox(std::shared_ptr<AnyListModel> tags, AnyInputBox* input_box,
+        QWidget* parent = nullptr);
 
       /** Returns the list of tags. */
       const std::shared_ptr<AnyListModel>& get_tags() const;
 
-      /** Returns the current text model. */
-      const std::shared_ptr<TextModel>& get_current() const;
+      /** Returns the input box. */
+      AnyInputBox& get_input_box();
 
-      /** Returns the highlight model. */
-      const std::shared_ptr<HighlightModel>& get_highlight() const;
+      /** Returns the input box. */
+      const AnyInputBox& get_input_box() const;
 
-      /** Sets the placeholder value. */
+      /** Sets the placeholder text. */
       void set_placeholder(const QString& placeholder);
 
-      /** Returns <code>true</code> iff this TagBox is read-only. */
+      /** Returns <code>true</code> iff this AnyTagBox is read-only. */
       bool is_read_only() const;
 
       /**
        * Sets the read-only state.
-       * @param is_read_only <code>true</code> iff the TagBox should be
+       * @param is_read_only <code>true</code> iff the AnyTagBox should be
        *        read-only.
        */
       void set_read_only(bool is_read_only);
-
-      /** Connects a slot to the SubmitSignal. */
-      boost::signals2::connection connect_submit_signal(
-        const SubmitSignal::slot_type& slot) const;
 
       QSize minimumSizeHint() const override;
       QSize sizeHint() const override;
 
     protected:
+
+      /**
+       * Returns <code>true</code> iff the input has no content under the caret,
+       * used to decide whether a backspace removes the trailing tag.
+       * The default returns <code>false</code>, and subclasses override to
+       * define emptiness for their input type.
+       */
+      virtual bool is_input_empty() const;
+
       bool eventFilter(QObject* watched, QEvent* event) override;
       bool event(QEvent* event) override;
       void changeEvent(QEvent* event) override;
@@ -69,16 +72,16 @@ namespace Spire {
       struct PartialListModel;
       struct TagItemBuilder;
       std::shared_ptr<PartialListModel> m_model;
-      TextBox* m_text_box;
+      AnyInputBox* m_input_box;
       ListView* m_list_view;
       ScrollableListBox* m_scrollable_list_box;
       ScrollBar* m_horizontal_scroll_bar;
       ScrollBar* m_vertical_scroll_bar;
       TextAreaBox* m_text_area_box;
       InfoTip* m_info_tip;
-      QWidget* m_text_focus_proxy;
+      QWidget* m_input_focus_proxy;
       FocusObserver m_focus_observer;
-      std::unique_ptr<GlobalPositionObserver> m_text_box_position_observer;
+      GlobalPositionObserver m_input_box_position_observer;
       boost::optional<Styles::Overflow> m_list_view_overflow;
       QString m_placeholder;
       bool m_is_read_only;
@@ -99,8 +102,8 @@ namespace Spire {
       int get_available_width() const;
       int get_height_for_width(int width) const;
       void set_overflow(Styles::Overflow overflow);
-      void install_text_proxy_event_filter();
-      void scroll_to_text_box();
+      void install_input_proxy_event_filter();
+      void scroll_to_input_box();
       void update_placeholder();
       void update_scroll_bar_end_range(ScrollBar& scroll_bar, int& end_range);
       void update_tags_read_only();
@@ -110,12 +113,48 @@ namespace Spire {
       void update_vertical_scroll_bar_visible();
       void on_focus(FocusObserver::State state);
       void on_operation(const AnyListModel::Operation& operation);
-      void on_text_box_current(const QString& current);
+      void on_input_current(const AnyRef& current);
       void on_list_view_current(const boost::optional<int>& current);
       void on_list_view_submit(const std::any& submission);
       void on_style();
       void on_list_view_style();
       void on_text_area_style();
+  };
+
+  /** A tag-list widget with a TextBox as its input. */
+  class TagBox : public AnyTagBox {
+    public:
+
+      /** Signals that the value in the TextBox is being submitted. */
+      using SubmitSignal = TextBox::SubmitSignal;
+
+      /**
+       * Constructs a TagBox.
+       * @param tags The list model which holds a list of tags.
+       * @param current The current text's model.
+       * @param parent The parent widget.
+       */
+      TagBox(std::shared_ptr<AnyListModel> tags,
+        std::shared_ptr<TextModel> current, QWidget* parent = nullptr);
+
+      /** Returns the current text model. */
+      const std::shared_ptr<TextModel>& get_current() const;
+
+      /** Returns the highlight model. */
+      const std::shared_ptr<HighlightModel>& get_highlight() const;
+
+      /** Connects a slot to the SubmitSignal. */
+      boost::signals2::connection connect_submit_signal(
+        const SubmitSignal::slot_type& slot) const;
+
+    protected:
+      bool is_input_empty() const override;
+
+    private:
+      TextBox* m_text_box;
+
+      TagBox(std::shared_ptr<AnyListModel> tags, TextBox* text_box,
+        QWidget* parent);
   };
 }
 

--- a/Applications/Spire/Source/Ui/TagBox.cpp
+++ b/Applications/Spire/Source/Ui/TagBox.cpp
@@ -319,11 +319,11 @@ const AnyRef& AnyTagBox::get_submission() const {
   return m_input_box->get_submission();
 }
 
-AnyInputBox& AnyTagBox::get_input_box() {
+const AnyInputBox& AnyTagBox::get_input_box() const {
   return *m_input_box;
 }
 
-const AnyInputBox& AnyTagBox::get_input_box() const {
+AnyInputBox& AnyTagBox::get_input_box() {
   return *m_input_box;
 }
 

--- a/Applications/Spire/Source/Ui/TagBox.cpp
+++ b/Applications/Spire/Source/Ui/TagBox.cpp
@@ -95,9 +95,17 @@ namespace {
     }
     return QWIDGETSIZE_MAX;
   }
+
+  TextBox* make_text_box(std::shared_ptr<TextModel> current) {
+    auto text_box = new TextBox(std::move(current));
+    update_style(*text_box, [] (auto& style) {
+      style = TEXT_BOX_STYLE(style);
+    });
+    return text_box;
+  }
 }
 
-struct TagBox::PartialListModel : public AnyListModel {
+struct AnyTagBox::PartialListModel : public AnyListModel {
   std::shared_ptr<AnyListModel> m_source;
   ListModelTransactionLog<std::any> m_transaction;
   scoped_connection m_source_connection;
@@ -155,20 +163,20 @@ struct TagBox::PartialListModel : public AnyListModel {
   }
 };
 
-struct TagBox::TagItemBuilder {
-  TagBox* m_tag_box;
+struct AnyTagBox::TagItemBuilder {
+  AnyTagBox* m_tag_box;
   std::unordered_map<QWidget*, std::shared_ptr<ProxyValueModel<QString>>>
     m_proxies;
 
-  explicit TagItemBuilder(TagBox& tag_box)
+  explicit TagItemBuilder(AnyTagBox& tag_box)
     : m_tag_box(&tag_box) {}
 
   QWidget* mount(const std::shared_ptr<AnyListModel>& list, int index) {
     if(index == list->get_size() - 1) {
       auto box = new QWidget();
-      enclose(*box, *m_tag_box->m_text_box);
+      enclose(*box, *m_tag_box->m_input_box);
       connect(box, &QObject::destroyed, m_tag_box, [tag_box = m_tag_box] {
-        tag_box->m_text_box->setParent(tag_box);
+        tag_box->m_input_box->setParent(tag_box);
       });
       return box;
     }
@@ -217,12 +225,14 @@ struct TagBox::TagItemBuilder {
   }
 };
 
-TagBox::TagBox(std::shared_ptr<AnyListModel> list,
-    std::shared_ptr<TextModel> current, QWidget* parent)
+AnyTagBox::AnyTagBox(std::shared_ptr<AnyListModel> tags,
+    AnyInputBox* input_box, QWidget* parent)
     : QWidget(parent),
-      m_model(std::make_shared<PartialListModel>(std::move(list))),
-      m_text_focus_proxy(nullptr),
+      m_model(std::make_shared<PartialListModel>(std::move(tags))),
+      m_input_box(input_box),
+      m_input_focus_proxy(nullptr),
       m_focus_observer(*this),
+      m_input_box_position_observer(*input_box),
       m_is_read_only(false),
       m_list_item_gap(0),
       m_list_overflow_gap(0),
@@ -230,12 +240,8 @@ TagBox::TagBox(std::shared_ptr<AnyListModel> list,
       m_horizontal_scroll_bar_end_range(0),
       m_vertical_scroll_bar_end_range(0),
       m_is_transaction(false) {
-  m_text_box = new TextBox(std::move(current));
-  update_style(*m_text_box, [] (auto& style) {
-    style = TEXT_BOX_STYLE(style);
-  });
-  m_text_box->get_current()->connect_update_signal(
-    std::bind_front(&TagBox::on_text_box_current, this));
+  m_input_box->get_current()->connect_update_signal(
+    std::bind_front(&AnyTagBox::on_input_current, this));
   m_list_view = new ListView(
     m_model, RecycledListViewItemBuilder(TagItemBuilder(*this)));
   m_list_view->get_current()->set(m_model->get_size() - 1);
@@ -243,13 +249,13 @@ TagBox::TagBox(std::shared_ptr<AnyListModel> list,
     style = LIST_VIEW_STYLE(style);
   });
   m_list_view_style_connection = connect_style_signal(
-    *m_list_view, std::bind_front(&TagBox::on_list_view_style, this));
+    *m_list_view, std::bind_front(&AnyTagBox::on_list_view_style, this));
   m_list_view->get_list()->connect_operation_signal(
-    std::bind_front(&TagBox::on_operation, this));
+    std::bind_front(&AnyTagBox::on_operation, this));
   m_list_view->connect_submit_signal(
-    std::bind_front(&TagBox::on_list_view_submit, this));
+    std::bind_front(&AnyTagBox::on_list_view_submit, this));
   m_list_view->get_current()->connect_update_signal(
-    std::bind_front(&TagBox::on_list_view_current, this));
+    std::bind_front(&AnyTagBox::on_list_view_current, this));
   m_list_view->setFocusPolicy(Qt::NoFocus);
   m_list_view->installEventFilter(this);
   m_scrollable_list_box = new ScrollableListBox(*m_list_view);
@@ -264,17 +270,17 @@ TagBox::TagBox(std::shared_ptr<AnyListModel> list,
   m_vertical_scroll_bar =
     &m_scrollable_list_box->get_scroll_box().get_vertical_scroll_bar();
   m_scrollable_list_box->installEventFilter(this);
-  auto input_box = make_input_box(m_scrollable_list_box);
-  enclose(*this, *input_box);
+  auto input_outline = make_input_box(m_scrollable_list_box);
+  enclose(*this, *input_outline);
   link(*this, *m_list_view);
-  proxy_style(*this, *input_box);
-  set_style(*this, INPUT_BOX_STYLE(get_style(*input_box)));
+  proxy_style(*this, *input_outline);
+  set_style(*this, INPUT_BOX_STYLE(get_style(*input_outline)));
   m_style_connection = connect_style_signal(*this,
-    std::bind_front(&TagBox::on_style, this));
+    std::bind_front(&AnyTagBox::on_style, this));
   m_text_area_box = new TextAreaBox("");
   m_text_area_box->set_read_only(true);
   m_text_area_box_style_connection = connect_style_signal(*m_text_area_box,
-    std::bind_front(&TagBox::on_text_area_style, this));
+    std::bind_front(&AnyTagBox::on_text_area_style, this));
   update_style(*m_text_area_box, [] (auto& style) {
     style = TEXT_AREA_BOX_STYLE(style);
   });
@@ -284,14 +290,12 @@ TagBox::TagBox(std::shared_ptr<AnyListModel> list,
   on_list_view_style();
   m_min_scroll_height = vertical_length(m_list_view_padding) +
     vertical_length(m_input_box_border) + vertical_length(m_input_box_padding) +
-      m_text_box->sizeHint().height();
-  setFocusProxy(m_text_box);
+      m_input_box->sizeHint().height();
+  setFocusProxy(m_input_box);
   setFocusPolicy(Qt::StrongFocus);
   m_focus_observer.connect_state_signal(
-    std::bind_front(&TagBox::on_focus, this));
-  m_text_box_position_observer =
-    std::make_unique<GlobalPositionObserver>(*m_text_box);
-  m_text_box_position_observer->connect_position_signal([=] (auto pos) {
+    std::bind_front(&AnyTagBox::on_focus, this));
+  m_input_box_position_observer.connect_position_signal([=] (auto pos) {
     if(m_list_view_overflow == Styles::Overflow::NONE) {
       update_tooltip();
     }
@@ -299,53 +303,48 @@ TagBox::TagBox(std::shared_ptr<AnyListModel> list,
   set_overflow(Overflow::NONE);
 }
 
-const std::shared_ptr<AnyListModel>& TagBox::get_tags() const {
+const std::shared_ptr<AnyListModel>& AnyTagBox::get_tags() const {
   return m_model->m_source;
 }
 
-const std::shared_ptr<TextModel>& TagBox::get_current() const {
-  return m_text_box->get_current();
+AnyInputBox& AnyTagBox::get_input_box() {
+  return *m_input_box;
 }
 
-const std::shared_ptr<HighlightModel>& TagBox::get_highlight() const {
-  return m_text_box->get_highlight();
+const AnyInputBox& AnyTagBox::get_input_box() const {
+  return *m_input_box;
 }
 
-void TagBox::set_placeholder(const QString& placeholder) {
+void AnyTagBox::set_placeholder(const QString& placeholder) {
   m_placeholder = placeholder;
   update_placeholder();
 }
 
-bool TagBox::is_read_only() const {
+bool AnyTagBox::is_read_only() const {
   return m_is_read_only;
 }
 
-void TagBox::set_read_only(bool is_read_only) {
+void AnyTagBox::set_read_only(bool is_read_only) {
   if(m_is_read_only == is_read_only) {
     return;
   }
   m_is_read_only = is_read_only;
-  m_text_box->set_read_only(m_is_read_only);
+  m_input_box->set_read_only(m_is_read_only);
   update_tags_read_only();
   if(m_is_read_only) {
     match(*this, ReadOnly());
   } else {
     m_list_view->setMinimumWidth(0);
-    install_text_proxy_event_filter();
+    install_input_proxy_event_filter();
     unmatch(*this, ReadOnly());
   }
 }
 
-connection TagBox::connect_submit_signal(
-    const SubmitSignal::slot_type& slot) const {
-  return m_text_box->connect_submit_signal(slot);
+QSize AnyTagBox::minimumSizeHint() const {
+  return QSize(QWidget::minimumSizeHint().width(), m_min_scroll_height);
 }
 
-QSize TagBox::minimumSizeHint() const {
-  return {QWidget::minimumSizeHint().width(), m_min_scroll_height};
-}
-
-QSize TagBox::sizeHint() const {
+QSize AnyTagBox::sizeHint() const {
   if(m_size_hint) {
     return *m_size_hint;
   }
@@ -355,14 +354,16 @@ QSize TagBox::sizeHint() const {
   return *m_size_hint;
 }
 
-bool TagBox::eventFilter(QObject* watched, QEvent* event) {
+bool AnyTagBox::is_input_empty() const {
+  return false;
+}
+
+bool AnyTagBox::eventFilter(QObject* watched, QEvent* event) {
   if(event->type() == QEvent::KeyPress) {
     auto& key_event = *static_cast<QKeyEvent*>(event);
-    if(watched == m_text_focus_proxy && !is_read_only() &&
+    if(watched == m_input_focus_proxy && !is_read_only() &&
         key_event.key() == Qt::Key_Backspace && get_tags()->get_size() > 0 &&
-          (m_text_box->get_highlight()->get().m_start == 0 &&
-            m_text_box->get_highlight()->get().m_end == 0 ||
-              m_text_box->get_current()->get().isEmpty())) {
+          is_input_empty()) {
       get_tags()->remove(get_tags()->get_size() - 1);
       return true;
     } else if(watched == m_list_view) {
@@ -388,14 +389,14 @@ bool TagBox::eventFilter(QObject* watched, QEvent* event) {
   return QWidget::eventFilter(watched, event);
 }
 
-bool TagBox::event(QEvent* event) {
+bool AnyTagBox::event(QEvent* event) {
   if(event->type() == QEvent::LayoutRequest) {
     m_size_hint = none;
   }
   return QWidget::event(event);
 }
 
-void TagBox::changeEvent(QEvent* event) {
+void AnyTagBox::changeEvent(QEvent* event) {
   if(event->type() == QEvent::EnabledChange) {
     update_tags_read_only();
     update_tooltip();
@@ -404,14 +405,14 @@ void TagBox::changeEvent(QEvent* event) {
   QWidget::changeEvent(event);
 }
 
-bool TagBox::focusNextPrevChild(bool next) {
+bool AnyTagBox::focusNextPrevChild(bool next) {
   if(next) {
-    m_text_box->setFocus(Qt::TabFocusReason);
+    m_input_box->setFocus(Qt::TabFocusReason);
   }
   return QWidget::focusNextPrevChild(next);
 }
 
-void TagBox::resizeEvent(QResizeEvent* event) {
+void AnyTagBox::resizeEvent(QResizeEvent* event) {
   update_overflow();
   update_placeholder();
   update_tooltip();
@@ -419,12 +420,12 @@ void TagBox::resizeEvent(QResizeEvent* event) {
   QWidget::resizeEvent(event);
 }
 
-void TagBox::showEvent(QShowEvent* event) {
-  install_text_proxy_event_filter();
+void AnyTagBox::showEvent(QShowEvent* event) {
+  install_input_proxy_event_filter();
   QWidget::showEvent(event);
 }
 
-int TagBox::get_available_width() const {
+int AnyTagBox::get_available_width() const {
   auto width = 0;
   for(auto i = 0; i < m_list_view->get_list()->get_size(); ++i) {
     auto item_size = m_list_view->get_list_item(i)->sizeHint();
@@ -437,7 +438,7 @@ int TagBox::get_available_width() const {
   return width;
 }
 
-int TagBox::get_height_for_width(int width) const {
+int AnyTagBox::get_height_for_width(int width) const {
   if(width <= 0 || m_list_view_overflow == Overflow::NONE ||
       m_list_view->get_list()->get_size() == 0) {
     return m_min_scroll_height;
@@ -472,7 +473,7 @@ int TagBox::get_height_for_width(int width) const {
   return total_height;
 }
 
-void TagBox::set_overflow(Overflow overflow) {
+void AnyTagBox::set_overflow(Overflow overflow) {
   if(overflow == m_list_view_overflow) {
     return;
   }
@@ -502,34 +503,34 @@ void TagBox::set_overflow(Overflow overflow) {
   m_list_view->updateGeometry();
 }
 
-void TagBox::install_text_proxy_event_filter() {
-  if(!m_text_focus_proxy) {
-    m_text_focus_proxy = m_text_box->focusProxy();
-    if(m_text_focus_proxy) {
-      m_text_focus_proxy->installEventFilter(this);
+void AnyTagBox::install_input_proxy_event_filter() {
+  if(!m_input_focus_proxy) {
+    m_input_focus_proxy = find_focus_proxy(*m_input_box);
+    if(m_input_focus_proxy) {
+      m_input_focus_proxy->installEventFilter(this);
     }
   }
 }
 
-void TagBox::scroll_to_text_box() {
+void AnyTagBox::scroll_to_input_box() {
   scroll_to_end(*m_horizontal_scroll_bar);
   scroll_to_end(*m_vertical_scroll_bar);
 }
 
-void TagBox::update_placeholder() {
+void AnyTagBox::update_placeholder() {
   if(m_model->m_source->get_size() == 0) {
-    m_text_box->set_placeholder(m_placeholder);
+    m_input_box->set_placeholder(m_placeholder);
     auto content_width = width() - horizontal_length(m_input_box_padding) -
       horizontal_length(m_input_box_border) -
       horizontal_length(m_list_view_padding);
-    m_text_box->setMinimumWidth(std::max(0, content_width));
+    m_input_box->setMinimumWidth(std::max(0, content_width));
   } else {
-    m_text_box->set_placeholder("");
-    m_text_box->setMinimumWidth(0);
+    m_input_box->set_placeholder("");
+    m_input_box->setMinimumWidth(0);
   }
 }
 
-void TagBox::update_scroll_bar_end_range(ScrollBar& scroll_bar,
+void AnyTagBox::update_scroll_bar_end_range(ScrollBar& scroll_bar,
     int& end_range) {
   if(scroll_bar.get_range().m_end != end_range) {
     scroll_to_end(scroll_bar);
@@ -537,7 +538,7 @@ void TagBox::update_scroll_bar_end_range(ScrollBar& scroll_bar,
   }
 }
 
-void TagBox::update_tags_read_only() {
+void AnyTagBox::update_tags_read_only() {
   auto is_read_only = m_is_read_only || !isEnabled();
   for(auto i = 0; i < m_model->m_source->get_size(); ++i) {
     auto& item = *m_list_view->get_list_item(i);
@@ -547,7 +548,7 @@ void TagBox::update_tags_read_only() {
   }
 }
 
-void TagBox::update_tip() {
+void AnyTagBox::update_tip() {
   static auto split_string = QString(" ") + QChar(0x2022) + " ";
   auto tip = QString();
   for(auto i = 0; i < get_tags()->get_size(); ++i) {
@@ -557,7 +558,7 @@ void TagBox::update_tip() {
   m_text_area_box->get_current()->set(tip);
 }
 
-void TagBox::update_tooltip() {
+void AnyTagBox::update_tooltip() {
   auto is_tag_overflow = [&] {
     if(m_list_view_overflow == Styles::Overflow::NONE) {
       auto scroll_bar_width = [&] {
@@ -600,7 +601,7 @@ void TagBox::update_tooltip() {
   }
 }
 
-void TagBox::update_overflow() {
+void AnyTagBox::update_overflow() {
   auto list_view_overflow = [&] {
     if(get_maximum_dimension<&QWidget::maximumHeight>(*this) <=
         m_min_scroll_height) {
@@ -611,7 +612,7 @@ void TagBox::update_overflow() {
   set_overflow(list_view_overflow);
 }
 
-void TagBox::update_vertical_scroll_bar_visible() {
+void AnyTagBox::update_vertical_scroll_bar_visible() {
   if(m_list_view_overflow == Overflow::WRAP &&
       m_list_view->sizeHint().height() + vertical_length(m_input_box_padding) +
       vertical_length(m_input_box_border) >
@@ -624,11 +625,11 @@ void TagBox::update_vertical_scroll_bar_visible() {
   }
 }
 
-void TagBox::on_focus(FocusObserver::State state) {
+void AnyTagBox::on_focus(FocusObserver::State state) {
   if(state == FocusObserver::State::NONE) {
     scroll_to_start(*m_horizontal_scroll_bar);
   } else {
-    m_text_box->setFocusPolicy(focusPolicy());
+    m_input_box->setFocusPolicy(focusPolicy());
     setFocus();
     if(!is_read_only()) {
       QTimer::singleShot(0, this, [=] {
@@ -638,7 +639,7 @@ void TagBox::on_focus(FocusObserver::State state) {
   }
 }
 
-void TagBox::on_operation(const AnyListModel::Operation& operation) {
+void AnyTagBox::on_operation(const AnyListModel::Operation& operation) {
   visit(operation,
     [&] (AnyListModel::StartTransaction) {
       m_is_transaction = true;
@@ -650,7 +651,7 @@ void TagBox::on_operation(const AnyListModel::Operation& operation) {
     m_list_view->setUpdatesEnabled(false);
   } else {
     m_list_view->setFocusPolicy(Qt::NoFocus);
-    m_text_box->setFocusPolicy(focusPolicy());
+    m_input_box->setFocusPolicy(focusPolicy());
     if(m_list_view_overflow == Overflow::NONE && is_read_only()) {
       m_list_view->setMinimumWidth(get_available_width() -
         horizontal_length(m_input_box_padding) -
@@ -672,28 +673,28 @@ void TagBox::on_operation(const AnyListModel::Operation& operation) {
   }
 }
 
-void TagBox::on_text_box_current(const QString& current) {
+void AnyTagBox::on_input_current(const AnyRef& current) {
   m_list_view->updateGeometry();
-  scroll_to_text_box();
+  scroll_to_input_box();
 }
 
-void TagBox::on_list_view_current(const optional<int>& current) {
+void AnyTagBox::on_list_view_current(const optional<int>& current) {
   if(current != m_model->get_size() - 1) {
     m_list_view->get_current()->set(m_model->get_size() - 1);
   }
 }
 
-void TagBox::on_list_view_submit(const std::any& submission) {
+void AnyTagBox::on_list_view_submit(const std::any& submission) {
   m_list_view->setFocusPolicy(Qt::NoFocus);
   setFocus();
   if(!m_is_read_only) {
-    scroll_to_text_box();
+    scroll_to_input_box();
   } else {
     scroll_to_start(*m_horizontal_scroll_bar);
   }
 }
 
-void TagBox::on_style() {
+void AnyTagBox::on_style() {
   auto has_update = std::make_shared<bool>(false);
   auto& stylist = find_stylist(*this);
   for(auto& property : stylist.get_computed_block()) {
@@ -768,7 +769,7 @@ void TagBox::on_style() {
   }
 }
 
-void TagBox::on_list_view_style() {
+void AnyTagBox::on_list_view_style() {
   auto has_update = std::make_shared<bool>(false);
   auto& stylist = find_stylist(*m_list_view);
   for(auto& property : stylist.get_computed_block()) {
@@ -827,7 +828,7 @@ void TagBox::on_list_view_style() {
   }
 }
 
-void TagBox::on_text_area_style() {
+void AnyTagBox::on_text_area_style() {
   auto text_font = std::make_shared<QFont>();
   auto horizontal_padding = std::make_shared<int>();
   auto& stylist = find_stylist(*m_text_area_box);
@@ -866,4 +867,34 @@ void TagBox::on_text_area_style() {
   }
   m_text_area_box->setMaximumWidth(
     50 * QFontMetrics(*text_font).averageCharWidth() + *horizontal_padding);
+}
+
+TagBox::TagBox(std::shared_ptr<AnyListModel> tags,
+  std::shared_ptr<TextModel> current, QWidget* parent)
+  : TagBox(std::move(tags), make_text_box(std::move(current)), parent) {}
+
+TagBox::TagBox(std::shared_ptr<AnyListModel> tags, TextBox* text_box,
+  QWidget* parent)
+  : AnyTagBox(std::move(tags), new AnyInputBox(*text_box), parent),
+    m_text_box(text_box) {}
+
+const std::shared_ptr<TextModel>& TagBox::get_current() const {
+  return m_text_box->get_current();
+}
+
+const std::shared_ptr<HighlightModel>& TagBox::get_highlight() const {
+  return m_text_box->get_highlight();
+}
+
+connection TagBox::connect_submit_signal(
+    const SubmitSignal::slot_type& slot) const {
+  return m_text_box->connect_submit_signal(slot);
+}
+
+bool TagBox::is_input_empty() const {
+  auto& highlight = m_text_box->get_highlight()->get();
+  if(highlight.m_start == 0 && highlight.m_end == 0) {
+    return true;
+  }
+  return m_text_box->get_current()->get().isEmpty();
 }

--- a/Applications/Spire/Source/Ui/TagBox.cpp
+++ b/Applications/Spire/Source/Ui/TagBox.cpp
@@ -307,6 +307,18 @@ const std::shared_ptr<AnyListModel>& AnyTagBox::get_tags() const {
   return m_model->m_source;
 }
 
+const std::shared_ptr<AnyValueModel>& AnyTagBox::get_current() const {
+  return m_input_box->get_current();
+}
+
+const std::shared_ptr<HighlightModel>& AnyTagBox::get_highlight() const {
+  return m_input_box->get_highlight();
+}
+
+const AnyRef& AnyTagBox::get_submission() const {
+  return m_input_box->get_submission();
+}
+
 AnyInputBox& AnyTagBox::get_input_box() {
   return *m_input_box;
 }
@@ -338,6 +350,11 @@ void AnyTagBox::set_read_only(bool is_read_only) {
     install_input_proxy_event_filter();
     unmatch(*this, ReadOnly());
   }
+}
+
+connection AnyTagBox::connect_submit_signal(
+    const SubmitSignal::slot_type& slot) const {
+  return m_input_box->connect_submit_signal(slot);
 }
 
 QSize AnyTagBox::minimumSizeHint() const {
@@ -884,6 +901,10 @@ const std::shared_ptr<TextModel>& TagBox::get_current() const {
 
 const std::shared_ptr<HighlightModel>& TagBox::get_highlight() const {
   return m_text_box->get_highlight();
+}
+
+const QString& TagBox::get_submission() const {
+  return m_text_box->get_submission();
 }
 
 connection TagBox::connect_submit_signal(


### PR DESCRIPTION
Add a `AnyTagBox` to accept `AnyInputBox` as its input widget, while `TagBox` inherits from `AnyTagBox` accepts `TextBox` as the input. This update is used to implement `TagListBox`, which inherits from `AnyTagBox` and uses `KeyInputBox` as its input widget.