### PR TITLE
Destroy the OverlayPanel window when hiding a DropDownBox panel.

### DIFF
--- a/Applications/Spire/Source/Ui/DropDownBox.cpp
+++ b/Applications/Spire/Source/Ui/DropDownBox.cpp
@@ -93,7 +93,11 @@ bool DropDownBox::DropDownPanelWrapper::is_visible() const {
 
 void DropDownBox::DropDownPanelWrapper::destroy() {
   std::visit([] (auto*& widget) {
-    delete_later(widget);
+    if(widget) {
+      auto window = widget->window();
+      widget = nullptr;
+      window->deleteLater();
+    }
   }, m_panel);
 }
 


### PR DESCRIPTION
This is a latent bug and cannot be reproduced using the current demo.

Previously `DropDownPanelWrapper::destroy` only called `delete_later` on the `DropDownList` / `EmptyState` body, leaving the surrounding `OverlayPanel` as an orphan child of `DropDownBox` with a dangling pointer to the freed body. A subsequent layout query could crash on the dangling pointer. The same change also reclaims the `OverlayPanel` subtree per open/close cycle, removing a leak that accumulated until the `DropDownBox` itself was destroyed.