### PR TITLE
Reimplemented AccountListBox as a TagComboBox alias.

### DIFF
--- a/Applications/Spire/Include/Spire/Ui/AccountListBox.hpp
+++ b/Applications/Spire/Include/Spire/Ui/AccountListBox.hpp
@@ -1,72 +1,33 @@
 #ifndef SPIRE_ACCOUNT_LIST_BOX_HPP
 #define SPIRE_ACCOUNT_LIST_BOX_HPP
-#include "Spire/Spire/ListModel.hpp"
 #include "Spire/Ui/AccountBox.hpp"
+#include "Spire/Ui/TagComboBox.hpp"
 
 namespace Spire {
-  template<typename> class TagComboBox;
 
   /** Represents a ListModel for a list of AccountListItem::Account values. */
   using AccountListModel = ListModel<AccountListItem::Account>;
 
-  /** Displays a list of accounts over an open set of account values. */
-  class AccountListBox : public QWidget {
-    public:
+  /** A TagComboBox specialized for an AccountListItem::Account. */
+  using AccountListBox = TagComboBox<AccountListItem::Account>;
 
-      /**
-       * Signals the submission of the list of accounts.
-       * @param submission The list of submitted accounts.
-       */
-      using SubmitSignal =
-        Signal<void (const std::shared_ptr<AccountListModel>& submission)>;
+  /**
+   * Returns a new AccountListBox using a default current model.
+   * @param accounts The set of accounts that can be queried.
+   * @param parent The parent widget.
+   */
+  AccountListBox* make_account_list_box(
+    std::shared_ptr<AccountQueryModel> accounts, QWidget* parent = nullptr);
 
-      /**
-       * Constructs an AccountListBox using a default current.
-       * @param accounts The set of accounts that can be queried.
-       * @param parent The parent widget.
-       */
-      explicit AccountListBox(std::shared_ptr<AccountQueryModel> accounts,
-        QWidget* parent = nullptr);
-
-      /**
-       * Constructs an AccountListBox.
-       * @param accounts The set of accounts that can be queried.
-       * @param current The current list of selected accounts.
-       * @param parent The parent widget.
-       */
-      AccountListBox(std::shared_ptr<AccountQueryModel> accounts,
-        std::shared_ptr<AccountListModel> current, QWidget* parent = nullptr);
-
-      /** Returns the set of accounts that can be queried. */
-      const std::shared_ptr<AccountQueryModel>& get_accounts() const;
-
-      /** Returns the current list of accounts. */
-      const std::shared_ptr<AccountListModel>& get_current() const;
-
-      /** Sets the placeholder value. */
-      void set_placeholder(const QString& placeholder);
-
-      /** Returns <code>true</code> iff this AccountListBox is read-only. */
-      bool is_read_only() const;
-
-      /**
-       * Sets the read-only state.
-       * @param is_read_only True iff the AccountListBox should be read-only.
-       */
-      void set_read_only(bool is_read_only);
-
-      /** Connects a slot to the submit signal. */
-      boost::signals2::connection connect_submit_signal(
-        const SubmitSignal::slot_type& slot) const;
-
-    private:
-      struct AccountToAccountIdQueryModel;
-      mutable SubmitSignal m_submit_signal;
-      std::shared_ptr<AccountToAccountIdQueryModel> m_accounts;
-      std::shared_ptr<AccountListModel> m_current;
-      TagComboBox<QString>* m_tag_combo_box;
-      boost::signals2::scoped_connection m_submit_connection;
-  };
+  /**
+   * Returns a new AccountListBox.
+   * @param accounts The set of accounts that can be queried.
+   * @param current The current list of selected accounts.
+   * @param parent The parent widget.
+   */
+  AccountListBox* make_account_list_box(
+    std::shared_ptr<AccountQueryModel> accounts,
+    std::shared_ptr<AccountListModel> current, QWidget* parent = nullptr);
 }
 
 #endif

--- a/Applications/Spire/Include/Spire/Ui/AccountListItem.hpp
+++ b/Applications/Spire/Include/Spire/Ui/AccountListItem.hpp
@@ -2,6 +2,7 @@
 #define SPIRE_ACCOUNT_LIST_ITEM_HPP
 #include <Beam/ServiceLocator/DirectoryEntry.hpp>
 #include <QImage>
+#include <QLocale>
 #include <QString>
 #include <QWidget>
 
@@ -39,6 +40,10 @@ namespace Spire {
     private:
       Account m_account;
   };
+
+  /** Returns the text representation of an Account. */
+  QString to_text(const AccountListItem::Account& account,
+    const QLocale& locale = QLocale());
 }
 
 #endif

--- a/Applications/Spire/Include/Spire/Ui/AccountListItem.hpp
+++ b/Applications/Spire/Include/Spire/Ui/AccountListItem.hpp
@@ -22,6 +22,8 @@ namespace Spire {
 
         /** The full name associated with the account. */
         QString m_name;
+
+        bool operator ==(const Account& other) const = default;
       };
 
       /**

--- a/Applications/Spire/Include/Spire/Ui/CustomQtVariants.hpp
+++ b/Applications/Spire/Include/Spire/Ui/CustomQtVariants.hpp
@@ -21,7 +21,6 @@
 #include "Nexus/Definitions/Venue.hpp"
 #include "Spire/Canvas/Tasks/Task.hpp"
 #include "Spire/Spire/AnyRef.hpp"
-#include "Spire/Ui/AccountListItem.hpp"
 
 namespace Spire {
 
@@ -115,10 +114,6 @@ namespace Spire {
   /** Returns the text representation of a time_duration. */
   QString to_text(
     boost::posix_time::time_duration time, const QLocale& locale = QLocale());
-
-  /** Returns the text representation of an Account. */
-  QString to_text(const AccountListItem::Account& account,
-    const QLocale& locale = QLocale());
 
   /** Returns the text representation of a DirectoryEntry. */
   QString to_text(

--- a/Applications/Spire/Include/Spire/Ui/CustomQtVariants.hpp
+++ b/Applications/Spire/Include/Spire/Ui/CustomQtVariants.hpp
@@ -21,6 +21,7 @@
 #include "Nexus/Definitions/Venue.hpp"
 #include "Spire/Canvas/Tasks/Task.hpp"
 #include "Spire/Spire/AnyRef.hpp"
+#include "Spire/Ui/AccountListItem.hpp"
 
 namespace Spire {
 
@@ -114,6 +115,10 @@ namespace Spire {
   /** Returns the text representation of a time_duration. */
   QString to_text(
     boost::posix_time::time_duration time, const QLocale& locale = QLocale());
+
+  /** Returns the text representation of an Account. */
+  QString to_text(const AccountListItem::Account& account,
+    const QLocale& locale = QLocale());
 
   /** Returns the text representation of a DirectoryEntry. */
   QString to_text(

--- a/Applications/Spire/Source/Ui/AccountListBox.cpp
+++ b/Applications/Spire/Source/Ui/AccountListBox.cpp
@@ -1,115 +1,19 @@
 #include "Spire/Ui/AccountListBox.hpp"
-#include <unordered_set>
 #include "Spire/Spire/ArrayListModel.hpp"
-#include "Spire/Spire/TransformListModel.hpp"
-#include "Spire/Styles/Stylist.hpp"
-#include "Spire/Ui/Layouts.hpp"
-#include "Spire/Ui/TagComboBox.hpp"
 
-using namespace boost;
-using namespace boost::signals2;
 using namespace Spire;
-using namespace Spire::Styles;
 
-struct AccountListBox::AccountToAccountIdQueryModel : QueryModel<QString> {
-  std::shared_ptr<AccountQueryModel> m_source;
-
-  explicit AccountToAccountIdQueryModel(
-    std::shared_ptr<AccountQueryModel> source)
-    : m_source(std::move(source)) {}
-
-  optional<QString> parse(const QString& query) override {
-    if(auto account = m_source->parse(query);
-        account && QString::fromStdString(
-          account->m_account.m_name).toLower() == query.toLower()) {
-      return QString::fromStdString(account->m_account.m_name);
-    }
-    return none;
-  }
-
-  QtPromise<std::vector<QString>> submit(const QString& query) override {
-    return m_source->submit(query).then(
-      [] (const std::vector<AccountListItem::Account>& matches) {
-        auto seen = std::unordered_set<QString>();
-        auto ids = std::vector<QString>();
-        ids.reserve(matches.size());
-        for(auto& match : matches) {
-          auto id = QString::fromStdString(match.m_account.m_name);
-          if(seen.insert(id).second) {
-            ids.push_back(id);
-          }
-        }
-        return ids;
-      });
-  }
-};
-
-AccountListBox::AccountListBox(
-  std::shared_ptr<AccountQueryModel> accounts, QWidget* parent)
-  : AccountListBox(std::move(accounts),
-      std::make_shared<ArrayListModel<AccountListItem::Account>>(), parent) {}
-
-AccountListBox::AccountListBox(std::shared_ptr<AccountQueryModel> accounts,
-    std::shared_ptr<AccountListModel> current, QWidget* parent)
-    : QWidget(parent),
-      m_accounts(std::make_shared<AccountToAccountIdQueryModel>(
-        std::move(accounts))),
-      m_current(std::move(current)) {
-  auto to_id = [] (const AccountListItem::Account& account) {
-    return QString::fromStdString(account.m_account.m_name);
-  };
-  auto from_id = [=] (const QString& id) {
-    if(auto account = m_accounts->m_source->parse(id)) {
-      return *account;
-    }
-    throw std::invalid_argument("Invalid account id.");
-  };
-  using IdListModel = decltype(TransformListModel(m_current, to_id, from_id));
-  m_tag_combo_box = new TagComboBox<QString>(m_accounts,
-    std::make_shared<IdListModel>(m_current, to_id, from_id),
-    [=] (const auto& list, auto index) {
-      if(auto account = m_accounts->m_source->parse(list->get(index))) {
-        return new AccountListItem(*account);
-      }
-      return new AccountListItem(AccountListItem::Account());
-    });
-  m_submit_connection = m_tag_combo_box->connect_submit_signal(
-    [=] (const std::shared_ptr<ListModel<QString>>& submission) {
-      auto submitted_accounts =
-        std::make_shared<ArrayListModel<AccountListItem::Account>>();
-      for(auto i = 0; i < submission->get_size(); ++i) {
-        if(auto account = m_accounts->m_source->parse(submission->get(i))) {
-          submitted_accounts->push(*account);
-        }
-      }
-      m_submit_signal(submitted_accounts);
-    });
-  enclose(*this, *m_tag_combo_box);
-  proxy_style(*this, *m_tag_combo_box);
-  setFocusProxy(m_tag_combo_box);
+AccountListBox* Spire::make_account_list_box(
+    std::shared_ptr<AccountQueryModel> accounts, QWidget* parent) {
+  return make_account_list_box(std::move(accounts),
+    std::make_shared<ArrayListModel<AccountListItem::Account>>(), parent);
 }
 
-const std::shared_ptr<AccountQueryModel>& AccountListBox::get_accounts() const {
-  return m_accounts->m_source;
-}
-
-const std::shared_ptr<AccountListModel>& AccountListBox::get_current() const {
-  return m_current;
-}
-
-void AccountListBox::set_placeholder(const QString& placeholder) {
-  m_tag_combo_box->set_placeholder(placeholder);
-}
-
-bool AccountListBox::is_read_only() const {
-  return m_tag_combo_box->is_read_only();
-}
-
-void AccountListBox::set_read_only(bool is_read_only) {
-  m_tag_combo_box->set_read_only(is_read_only);
-}
-
-connection AccountListBox::connect_submit_signal(
-    const SubmitSignal::slot_type& slot) const {
-  return m_submit_signal.connect(slot);
+AccountListBox* Spire::make_account_list_box(
+    std::shared_ptr<AccountQueryModel> accounts,
+    std::shared_ptr<AccountListModel> current, QWidget* parent) {
+  return new AccountListBox(std::move(accounts), std::move(current),
+    [] (const std::shared_ptr<AccountListModel>& list, int index) {
+      return new AccountListItem(list->get(index));
+    }, parent);
 }

--- a/Applications/Spire/Source/Ui/CustomQtVariants.cpp
+++ b/Applications/Spire/Source/Ui/CustomQtVariants.cpp
@@ -1,6 +1,7 @@
 #include "Spire/Ui/CustomQtVariants.hpp"
 #include <Beam/TimeService/ToLocalTime.hpp>
 #include <QStyledItemDelegate>
+#include "Spire/Ui/AccountListItem.hpp"
 
 using namespace Beam;
 using namespace boost;

--- a/Applications/Spire/Source/Ui/CustomQtVariants.cpp
+++ b/Applications/Spire/Source/Ui/CustomQtVariants.cpp
@@ -278,6 +278,11 @@ QString Spire::to_text(posix_time::time_duration time, const QLocale& locale) {
   return QString::fromStdString(to_simple_string(time));
 }
 
+QString Spire::to_text(
+    const AccountListItem::Account& account, const QLocale& locale) {
+  return QString::fromStdString(account.m_account.m_name);
+}
+
 QString Spire::to_text(const DirectoryEntry& entry, const QLocale& locale) {
   return QString::fromStdString(entry.m_name);
 }
@@ -509,6 +514,8 @@ QString Spire::to_text(const std::any& value, const QLocale& locale) {
     return to_text(std::any_cast<ptime>(value), locale);
   } else if(value.type() == typeid(posix_time::time_duration)) {
     return to_text(std::any_cast<posix_time::time_duration>(value), locale);
+  } else if(value.type() == typeid(AccountListItem::Account)) {
+    return to_text(std::any_cast<AccountListItem::Account>(value), locale);
   } else if(value.type() == typeid(CountryCode)) {
     return to_text(std::any_cast<CountryCode>(value), locale);
   } else if(value.type() == typeid(CurrencyId)) {

--- a/Applications/Spire/Source/UiViewer/StandardUiProfiles.cpp
+++ b/Applications/Spire/Source/UiViewer/StandardUiProfiles.cpp
@@ -1359,7 +1359,7 @@ UiProfile Spire::make_account_list_box_profile() {
   properties.push_back(make_standard_property<QString>("placeholder"));
   properties.push_back(make_standard_property("read_only", false));
   return UiProfile("AccountListBox", properties, [] (auto& profile) {
-    auto box = new AccountListBox(populate_account_query_model());
+    auto box = make_account_list_box(populate_account_query_model());
     box->setMinimumWidth(scale_width(112));
     apply_widget_properties(box, profile.get_properties());
     auto& placeholder = get<QString>("placeholder", profile.get_properties());


### PR DESCRIPTION
Since `AccountListItem::Account` now has a `to_text(AccountListItem::Account, ...)` overload, `AccountListBox` no longer requires a dedicated widget implementation and has been updated to a type alias with corresponding factory functions.